### PR TITLE
Remove FUEL_TYPES mapping and update fuel name usage

### DIFF
--- a/custom_components/osservaprezzi_carburanti/config_flow.py
+++ b/custom_components/osservaprezzi_carburanti/config_flow.py
@@ -25,7 +25,6 @@ from .const import (
     DEFAULT_HEADERS,
     CONF_CONFIG_TYPE,
     CONF_TYPE_STATION,
-    FUEL_TYPES,
 )
 from .cron_helper import validate_cron_expression
 
@@ -57,11 +56,6 @@ async def _validate_station(hass: HomeAssistant, station_id: str) -> dict[str, A
                 raise CannotConnect(f"Service error: {response.status}")
     except (aiohttp.ClientError, asyncio.TimeoutError) as err:
         raise CannotConnect(f"Connection error: {err}")
-
-
-def _get_fuel_types() -> dict[int, str]:
-    """Get fuel types from static mapping."""
-    return FUEL_TYPES
 
 
 class OsservaprezziCarburantiConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):

--- a/custom_components/osservaprezzi_carburanti/const.py
+++ b/custom_components/osservaprezzi_carburanti/const.py
@@ -98,44 +98,6 @@ ADDITIONAL_SERVICES = {
     }
 }
 
-# Fuel types mapping
-FUEL_TYPES = {
-    1: "Benzina",
-    2: "Gasolio",
-    3: "Metano",
-    4: "GPL",
-    5: "Blue Super",
-    6: "Hi-Q Diesel",
-    7: "Benzina WR 100",
-    8: "Benzina Shell V Power",
-    9: "Diesel Shell V Power",
-    10: "Gasolio Premium",
-    11: "Gasolio artico", # Retained original entry
-    12: "Benzina Plus 98",
-    13: "Gasolio Oro Diesel",
-    19: "Gasolio artico", # Added new entry
-    20: "Blue Diesel",
-    26: "Benzina speciale",
-    27: "Gasolio speciale",
-    28: "HiQ Perform+",
-    231: "DieselMax",
-    308: "S-Diesel",
-    323: "L-GNC",
-    324: "GNL",
-    327: "Supreme Diesel",
-    328: "E-DIESEL",
-    341: "Excellium Diesel",
-    394: "HVOlution",
-    401: "HVO100",
-    404: "HVO",
-    406: "HVO",
-    410: "BCHVO",
-    424: "HVO",
-    435: "HVO",
-    452: "Diesel HVO",
-    473: "HVO"
-}
-
 # Headers for API calls
 DEFAULT_HEADERS = {
     "Accept": "application/json",

--- a/custom_components/osservaprezzi_carburanti/coordinator.py
+++ b/custom_components/osservaprezzi_carburanti/coordinator.py
@@ -11,7 +11,6 @@ from .const import (
     BASE_URL,
     DEFAULT_HEADERS,
     STATION_ENDPOINT,
-    FUEL_TYPES,
     DOMAIN,
     CONF_CONFIG_TYPE,
     CONF_TYPE_STATION,
@@ -85,9 +84,6 @@ class CarburantiDataUpdateCoordinator(DataUpdateCoordinator):
             raise UpdateFailed(f"Error fetching station data: {err}")
 
 
-    def _get_fuel_types(self) -> dict[int, str]:
-        """Get fuel types from static mapping."""
-        return FUEL_TYPES
 
 
     async def _async_get_station_coordinates(self, station_id: str | None, address: str | None = None, station_name: str | None = None) -> dict[str, Any] | None:
@@ -191,7 +187,7 @@ class CarburantiDataUpdateCoordinator(DataUpdateCoordinator):
         }
         for fuel in data.get("fuels", []):
             fuel_id = fuel.get("fuelId")
-            fuel_name = FUEL_TYPES.get(fuel_id, "Unknown")
+            fuel_name = fuel.get("name", "Unknown")
             service_type = "self" if fuel.get("isSelf") else "servito"
             fuel_key = f"{fuel_name}_{service_type}"
             processed_data["fuels"][fuel_key] = {


### PR DESCRIPTION
Eliminated the static FUEL_TYPES mapping from const.py and its usage in config_flow.py and coordinator.py. Fuel names are now obtained directly from the API response