### PR TITLE
Use Home Assistant `.storage` folder to persist both CSV and cache files

### DIFF
--- a/custom_components/osservaprezzi_carburanti/csv_manager.py
+++ b/custom_components/osservaprezzi_carburanti/csv_manager.py
@@ -9,7 +9,7 @@ from datetime import datetime, timedelta
 from typing import Any, Dict, List, Optional
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
-from .const import DEFAULT_HEADERS, CSV_URL, CSV_UPDATE_INTERVAL
+from .const import DOMAIN, DEFAULT_HEADERS, CSV_URL, CSV_UPDATE_INTERVAL
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -36,8 +36,8 @@ class CSVStationManager:
         self.session = async_get_clientsession(hass)
         self._stations_cache: Dict[str, Dict[str, Any]] = {}
         self._last_update: Optional[datetime] = None
-        self._csv_path = hass.config.path("osservaprezzi_stations.csv")
-        self._cache_path = hass.config.path("osservaprezzi_cache.json")
+        self._csv_path = hass.config.path(".storage", f"{DOMAIN}_stations.csv")
+        self._cache_path = hass.config.path(".storage", f"{DOMAIN}_cache.json")
         
     async def async_update_csv_data(self, force_update: bool = False) -> bool:
         """Update CSV data from the remote source."""


### PR DESCRIPTION
This PR aim to change the folder used to persist both CSV and cache files to a more proper one.

Currently, those files are saved in the `config` directory of HA, mixed with other configuration files used by HA itself. The proper folder to store those files is `.storage`, using the integration domain to avoid name collision with other integrations.

This change doesn't handle, nor delete, the (eventually) copy of those files inside `config`.

(P.S.: Thanks for sharing this integration, maybe I will uninstall other apps from my phone in the long run :))