### PR TITLE
feat: services, geo_location, retry logic, price tracking, tests & project docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,36 @@
+# Repomix
 /repomix-output.xml
 /repomix.config.json
+
+# Python
+__pycache__/
+*.py[cod]
+*$py.class
+*.so
+
+# Virtual environments
+.venv/
+venv/
+env/
+
+# Testing
+.pytest_cache/
+.coverage
+htmlcov/
+.mypy_cache/
+
+# IDE
+.idea/
+.vscode/
+*.swp
+*.swo
+*~
+
+# OS
+.DS_Store
+Thumbs.db
+
+# Distribution
+dist/
+build/
+*.egg-info/

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,3 @@
-# Repomix
-/repomix-output.xml
-/repomix.config.json
-
 # Python
 __pycache__/
 *.py[cod]

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,15 +15,17 @@ This is a **Home Assistant custom integration** (HACS) called "Osservaprezzi Car
 
 ```
 custom_components/osservaprezzi_carburanti/
-  __init__.py          # Entry point: setup/unload/reload config entries, cron scheduling
+  __init__.py          # Entry point: setup/unload/reload config entries, cron scheduling, services
   api.py               # Async API helper: fetches station data from MISE REST API
   config_flow.py       # Config & options flow (station ID input, cron expression)
   const.py             # Constants: domain, config keys, API URLs, service maps, headers
-  coordinator.py       # DataUpdateCoordinator: orchestrates data fetch + CSV enrichment
+  coordinator.py       # DataUpdateCoordinator: orchestrates data fetch + CSV enrichment + retry/backoff
   cron_helper.py       # Cron expression validation and next-run calculation (cronsim)
   csv_manager.py       # Downloads/parses/caches a large CSV of all Italian stations
+  geo_location.py      # GeoLocation platform: exposes stations on the HA map
   manifest.json        # HACS/HA manifest (domain, version, codeowners, etc.)
   sensor.py            # Sensor + BinarySensor entities (fuel prices, info, hours, services)
+  services.yaml        # Service definitions for HA UI
   translations/
     en.json            # English UI strings
     it.json            # Italian UI strings
@@ -166,6 +168,7 @@ from .coordinator import CarburantiDataUpdateCoordinator
 - **Cron scheduling**: uses `cronsim` library (soft dependency, gracefully degrades if missing)
 - **CSV data**: downloaded from MIMIT government site, parsed with auto-detected separator (`|` or `;`), cached in `.storage/` as JSON
 - **Config entry version**: currently `2` (see `VERSION` in config_flow and `async_migrate_entry`)
-- **Platform**: only `SENSOR` platform is registered
+- **Platform**: `SENSOR` and `GEO_LOCATION` platforms are registered
+- **Services**: three global services (`force_csv_update`, `clear_cache`, `compare_stations`) registered once and cleaned up on last entry unload
 - **Update mechanism**: cron-based rescheduling via `async_track_time_interval`, not `update_interval` on the coordinator
 - **Fuel key format**: `"{fuel_name}_{service_type}"` where service_type is `"self"` or `"servito"`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,171 @@
+# AGENTS.md
+
+Guide for agentic coding agents working in this repository.
+
+## Project Overview
+
+This is a **Home Assistant custom integration** (HACS) called "Osservaprezzi Carburanti" that retrieves Italian fuel prices from the MISE/Osservaprezzi government API. It is distributed via HACS and runs inside the Home Assistant ecosystem.
+
+- **Domain**: `osservaprezzi_carburanti`
+- **Integration type**: `service` (cloud_polling)
+- **Python version**: 3.11+ (uses `from __future__ import annotations` and `X | None` union syntax)
+- **Source root**: `custom_components/osservaprezzi_carburanti/`
+
+## Repository Structure
+
+```
+custom_components/osservaprezzi_carburanti/
+  __init__.py          # Entry point: setup/unload/reload config entries, cron scheduling
+  api.py               # Async API helper: fetches station data from MISE REST API
+  config_flow.py       # Config & options flow (station ID input, cron expression)
+  const.py             # Constants: domain, config keys, API URLs, service maps, headers
+  coordinator.py       # DataUpdateCoordinator: orchestrates data fetch + CSV enrichment
+  cron_helper.py       # Cron expression validation and next-run calculation (cronsim)
+  csv_manager.py       # Downloads/parses/caches a large CSV of all Italian stations
+  manifest.json        # HACS/HA manifest (domain, version, codeowners, etc.)
+  sensor.py            # Sensor + BinarySensor entities (fuel prices, info, hours, services)
+  translations/
+    en.json            # English UI strings
+    it.json            # Italian UI strings
+.github/workflows/
+  main.yml             # CI: HACS validation + hassfest
+```
+
+## Build / Lint / Test Commands
+
+### Validation (CI)
+
+```bash
+# These run in GitHub Actions on every push/PR:
+
+# 1. HACS validation (checks repository structure, manifest, etc.)
+#    Uses: hacs/action@22.5.0 with category "integration"
+
+# 2. Hassfest (Home Assistant's integration linter/validator)
+#    Uses: home-assistant/actions/hassfest@master
+```
+
+### Local validation
+
+There is no local test suite, no `pyproject.toml`, no `pytest.ini`, and no `requirements.txt` content. To validate locally:
+
+```bash
+# Install hassfest locally (optional, for pre-push validation)
+pip install hassfest
+hassfest --action validate --path .
+
+# Install hacs/validation locally (optional)
+pip install hacs
+hacs validate integration custom_components/osservaprezzi_carburanti
+```
+
+### Running tests
+
+There are **no tests** in this repository. If adding tests, use **pytest** with **pytest-asyncio** and the `homeassistant` test helpers (`pytest-homeassistant-custom-component`). Place tests in a `tests/` directory at the repo root.
+
+To run a single test file:
+```bash
+pytest tests/test_sensor.py
+```
+
+To run a single test function:
+```bash
+pytest tests/test_sensor.py::test_function_name -v
+```
+
+## Code Style Guidelines
+
+### Imports
+
+Order: **stdlib → third-party → homeassistant → local (relative)**, separated by blank lines. Every file starts with:
+
+```python
+from __future__ import annotations
+```
+
+Example import block (from `sensor.py`):
+```python
+from __future__ import annotations
+import logging
+from datetime import datetime, time, timedelta
+from typing import Any
+
+from homeassistant.components.sensor import SensorEntity, SensorStateClass
+from homeassistant.components.binary_sensor import BinarySensorEntity
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity import DeviceInfo, EntityCategory
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+from homeassistant.helpers.typing import StateType
+from homeassistant.util import dt as dt_util
+
+from .const import (
+    DOMAIN,
+    CONF_STATION_ID,
+    ...
+)
+from .coordinator import CarburantiDataUpdateCoordinator
+```
+
+### Type Annotations
+
+- Use modern union syntax: `str | None` (not `Optional[str]`), `dict[str, Any]` (not `Dict[str, Any]`)
+- Some older-style `Optional` and `Dict` imports exist in `csv_manager.py`; prefer modern syntax for new code
+- Always annotate function parameters and return types
+- Use `from __future__ import annotations` in every file to enable forward references
+
+### Naming Conventions
+
+- **Constants**: `UPPER_SNAKE_CASE` in `const.py` (e.g., `DOMAIN`, `CONF_STATION_ID`, `BASE_URL`)
+- **Functions/Methods**: `snake_case` (e.g., `async_setup_entry`, `_parse_time`)
+- **Classes**: `PascalCase` (e.g., `CarburantiDataUpdateCoordinator`, `StationInfoSensor`)
+- **Private methods**: Prefix with `_` (e.g., `_async_update_data`, `_is_currently_open`)
+- **Module-level logger**: `_LOGGER = logging.getLogger(__name__)`
+- **Config entry IDs**: `entry.entry_id`, `entry.data[CONF_STATION_ID]`
+
+### Logging
+
+- Always use `_LOGGER = logging.getLogger(__name__)` at module level
+- Use `_LOGGER.debug()` for detailed flow, `_LOGGER.info()` for key events, `_LOGGER.warning()` for recoverable issues, `_LOGGER.error()` for failures
+- Use `%s` style string formatting in log calls (not f-strings): `_LOGGER.info("Setting up %s", entry.title)`
+
+### Error Handling
+
+- API errors: catch specific `aiohttp.ClientResponseError` and `aiohttp.ClientError`, re-raise as `UpdateFailed` in the coordinator
+- Config flow: define custom exceptions extending `HomeAssistantError` (e.g., `CannotConnect`, `InvalidStation`)
+- Use `try/except` around parsing code with specific exception types; log and return safe defaults
+- Never silently swallow exceptions without logging
+
+### Async Patterns
+
+- All HA-facing functions are `async def`
+- Use `async_get_clientsession(hass)` for HTTP requests (never create raw `aiohttp.ClientSession`)
+- Use `hass.async_add_executor_job()` or `asyncio.to_thread()` to offload blocking I/O (file ops, heavy CSV parsing)
+- Coordinator pattern: extend `DataUpdateCoordinator`, implement `_async_update_data()`
+- Sensor entities: extend `CoordinatorEntity` + `SensorEntity` or `BinarySensorEntity`
+
+### Entity Patterns
+
+- Use `_attr_*` class attributes for static entity properties (e.g., `_attr_entity_category`, `_attr_icon`, `_attr_state_class`)
+- Use `_attr_translation_key` for translatable entity names; add keys to `translations/en.json` and `translations/it.json`
+- Use `_attr_unique_id` for stable entity IDs: `f"{station_id}_{descriptor}"`
+- `DeviceInfo` must use `identifiers={(DOMAIN, station_id)}` for all entities of the same station
+- `device_info` should be a `@property` returning `DeviceInfo` with name, manufacturer, model
+- All sensor platforms use `async_setup_entry(hass, entry, async_add_entities)` as the entry point
+
+### Comments
+
+- Comments in this codebase are in English
+- Use `"""docstrings"""` for classes and public functions
+- Inline comments are sparse; use them only for non-obvious logic
+- Do NOT add comments unless asked
+
+### Key Conventions
+
+- **Cron scheduling**: uses `cronsim` library (soft dependency, gracefully degrades if missing)
+- **CSV data**: downloaded from MIMIT government site, parsed with auto-detected separator (`|` or `;`), cached in `.storage/` as JSON
+- **Config entry version**: currently `2` (see `VERSION` in config_flow and `async_migrate_entry`)
+- **Platform**: only `SENSOR` platform is registered
+- **Update mechanism**: cron-based rescheduling via `async_track_time_interval`, not `update_interval` on the coordinator
+- **Fuel key format**: `"{fuel_name}_{service_type}"` where service_type is `"self"` or `"servito"`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,71 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [2.1.5] - 2025-01-XX
+
+### Added
+- HA services: `force_csv_update` and `clear_cache` for manual CSV data management
+- `geo_location` platform: stations appear on the HA map panel
+- Price change detection: `previous_price` and `price_changed_at` attributes on fuel sensors
+- Multi-station comparison service: `compare_stations` returns price data for all configured stations
+- Retry with exponential backoff (3 retries: 30s, 60s, 120s) for transient API failures
+
+### Changed
+- Improved error resilience in API and coordinator
+
+## [2.1.4] - 2025-01-18
+
+### Fixed
+- Fix indentation in CSV cache loader
+- Fix resilient dict parsing and KeyError avoidance in service sensors
+- Fix TypeError when subtracting naive datetimes loaded from storage
+
+### Changed
+- Replace aiofiles with `asyncio.to_thread` file I/O (remove external dependency)
+- Remove cronsim requirement from manifest (soft dependency)
+- Require cronsim and use HA dt_util for timezone handling
+- Normalize git line endings for translation mappings
+- Extract HTTP communication and error handling to `api.py`
+
+## [2.1.3] - 2025-01-12
+
+### Added
+- Migrate CSV and cache files to Home Assistant `.storage` directory with legacy file migration support
+
+### Changed
+- Auto-detect CSV separator (pipe `|` or semicolon `;`) and bump cache version to 2.0
+
+## [2.1.0] - 2024-12-XX
+
+### Added
+- Map integration with station location sensor and GPS coordinates
+- Flexible cron-based update scheduling via options flow
+
+### Changed
+- Remove zone search functionality and hardcoded fuel type mapping
+- Remove FUEL_TYPES mapping; use dynamic fuel names from API
+
+## [2.0.0] - 2024-11-XX
+
+### Added
+- Station opening hours sensors (open/closed status, next schedule change)
+- Binary sensors for station additional services (food, workshop, Wi-Fi, EV charging, etc.)
+- Italian holiday detection for opening hours
+
+### Changed
+- Refactor integration to `osservaprezzi_carburanti` domain
+- Refactor update scheduling and options flow
+
+## [1.0.0] - 2024-10-XX
+
+### Added
+- Initial release
+- Fuel price sensors for Italian gas stations via MISE Osservaprezzi API
+- Station information sensors (name, address, brand, contact info)
+- Config flow with station ID input
+- HACS integration support
+- Italian and English translations

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024-2025 casungo
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/custom_components/osservaprezzi_carburanti/__init__.py
+++ b/custom_components/osservaprezzi_carburanti/__init__.py
@@ -1,13 +1,17 @@
 from __future__ import annotations
+
 import logging
+from collections.abc import Callable
 from datetime import datetime
 from typing import Any
+
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant, ServiceCall, ServiceResponse, SupportsResponse
 from homeassistant.exceptions import ConfigEntryNotReady
-from homeassistant.helpers.event import async_track_time_interval
+from homeassistant.helpers.event import async_track_point_in_utc_time
 from homeassistant.util import dt as dt_util
+
 from .const import (
     DOMAIN,
     CONF_CRON_EXPRESSION,
@@ -17,7 +21,7 @@ from .const import (
     SERVICE_COMPARE_STATIONS,
 )
 from .coordinator import CarburantiDataUpdateCoordinator
-from .cron_helper import get_schedule_interval
+from .cron_helper import get_next_run_time
 
 _LOGGER = logging.getLogger(__name__)
 PLATFORMS: list[Platform] = [Platform.SENSOR]
@@ -36,41 +40,43 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     cron_expression = entry.options.get(CONF_CRON_EXPRESSION, DEFAULT_CRON_EXPRESSION)
     _LOGGER.info("Setting up cron schedule for %s with expression: %s", entry.title, cron_expression)
     
-    async def _request_refresh(now):
-        _LOGGER.info("Executing scheduled refresh for %s at %s", entry.title, now)
-        await coordinator.async_request_refresh()
-
-        try:
-            interval = get_schedule_interval(cron_expression)
-            next_run_time = dt_util.now() + interval
-            _LOGGER.info("Rescheduling next refresh for %s in %s (at %s)", entry.title, interval, next_run_time)
-            new_listener = async_track_time_interval(
-                hass,
-                _request_refresh,
-                interval
-            )
-            hass.data[DOMAIN][entry.entry_id]["listener"]()
-            hass.data[DOMAIN][entry.entry_id]["listener"] = new_listener
-        except Exception as e:
-            _LOGGER.error("Failed to reschedule: %s", e)
-
-    try:
-        interval = get_schedule_interval(cron_expression)
-        next_run_time = dt_util.now() + interval
-        _LOGGER.info("Initial cron schedule for %s: next refresh in %s (at %s)", entry.title, interval, next_run_time)
-        listener = async_track_time_interval(
-            hass,
-            _request_refresh,
-            interval
-        )
-    except Exception as e:
-        _LOGGER.error("Failed to set up cron schedule: %s", e)
-        return False
-
     hass.data.setdefault(DOMAIN, {})[entry.entry_id] = {
         "coordinator": coordinator,
-        "listener": listener,
+        "listener": None,
     }
+
+    def _schedule_next_refresh() -> None:
+        try:
+            next_run_time = get_next_run_time(cron_expression)
+        except Exception as err:
+            _LOGGER.error("Failed to compute next cron schedule for %s: %s", entry.title, err)
+            raise
+
+        _LOGGER.info(
+            "Scheduling next refresh for %s at %s",
+            entry.title,
+            next_run_time,
+        )
+        listener: Callable[[], None] = async_track_point_in_utc_time(
+            hass,
+            _request_refresh,
+            dt_util.as_utc(next_run_time),
+        )
+        hass.data[DOMAIN][entry.entry_id]["listener"] = listener
+
+    async def _request_refresh(now: datetime) -> None:
+        _LOGGER.info("Executing scheduled refresh for %s at %s", entry.title, now)
+        try:
+            await coordinator.async_request_refresh()
+        finally:
+            _schedule_next_refresh()
+
+    try:
+        _schedule_next_refresh()
+    except Exception:
+        await coordinator.async_shutdown()
+        hass.data[DOMAIN].pop(entry.entry_id, None)
+        return False
 
     _async_register_services(hass)
 

--- a/custom_components/osservaprezzi_carburanti/__init__.py
+++ b/custom_components/osservaprezzi_carburanti/__init__.py
@@ -20,7 +20,7 @@ from .coordinator import CarburantiDataUpdateCoordinator
 from .cron_helper import get_schedule_interval
 
 _LOGGER = logging.getLogger(__name__)
-PLATFORMS: list[Platform] = [Platform.SENSOR, Platform.GEO_LOCATION]
+PLATFORMS: list[Platform] = [Platform.SENSOR]
 
 _SERVICES_REGISTERED = f"{DOMAIN}_services_registered"
 

--- a/custom_components/osservaprezzi_carburanti/__init__.py
+++ b/custom_components/osservaprezzi_carburanti/__init__.py
@@ -1,18 +1,29 @@
 from __future__ import annotations
 import logging
 from datetime import datetime
+from typing import Any
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import Platform
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, ServiceCall, ServiceResponse, SupportsResponse
 from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers.event import async_track_time_interval
 from homeassistant.util import dt as dt_util
-from .const import DOMAIN, CONF_CRON_EXPRESSION, DEFAULT_CRON_EXPRESSION
+from .const import (
+    DOMAIN,
+    CONF_CRON_EXPRESSION,
+    DEFAULT_CRON_EXPRESSION,
+    SERVICE_FORCE_CSV_UPDATE,
+    SERVICE_CLEAR_CACHE,
+    SERVICE_COMPARE_STATIONS,
+)
 from .coordinator import CarburantiDataUpdateCoordinator
 from .cron_helper import get_schedule_interval
 
 _LOGGER = logging.getLogger(__name__)
-PLATFORMS: list[Platform] = [Platform.SENSOR]
+PLATFORMS: list[Platform] = [Platform.SENSOR, Platform.GEO_LOCATION]
+
+_SERVICES_REGISTERED = f"{DOMAIN}_services_registered"
+
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     coordinator = CarburantiDataUpdateCoordinator(hass, entry)
@@ -22,7 +33,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         await coordinator.async_shutdown()
         raise
     
-    # Get cron expression from options
     cron_expression = entry.options.get(CONF_CRON_EXPRESSION, DEFAULT_CRON_EXPRESSION)
     _LOGGER.info("Setting up cron schedule for %s with expression: %s", entry.title, cron_expression)
     
@@ -30,24 +40,20 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         _LOGGER.info("Executing scheduled refresh for %s at %s", entry.title, now)
         await coordinator.async_request_refresh()
 
-        # Reschedule for next run time
         try:
             interval = get_schedule_interval(cron_expression)
             next_run_time = dt_util.now() + interval
             _LOGGER.info("Rescheduling next refresh for %s in %s (at %s)", entry.title, interval, next_run_time)
-            # Create new listener for next run
             new_listener = async_track_time_interval(
                 hass,
                 _request_refresh,
                 interval
             )
-            # Replace the listener in hass.data
             hass.data[DOMAIN][entry.entry_id]["listener"]()
             hass.data[DOMAIN][entry.entry_id]["listener"] = new_listener
         except Exception as e:
             _LOGGER.error("Failed to reschedule: %s", e)
 
-    # Set initial schedule
     try:
         interval = get_schedule_interval(cron_expression)
         next_run_time = dt_util.now() + interval
@@ -66,16 +72,91 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         "listener": listener,
     }
 
+    _async_register_services(hass)
+
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
     entry.async_on_unload(entry.add_update_listener(async_reload_entry))
     return True
 
+
+def _async_register_services(hass: HomeAssistant) -> None:
+    if hass.data.get(_SERVICES_REGISTERED):
+        return
+    hass.data[_SERVICES_REGISTERED] = True
+
+    async def _handle_force_csv_update(call: ServiceCall) -> None:
+        _LOGGER.info("Service force_csv_update triggered")
+        for entry_id, entry_data in hass.data.get(DOMAIN, {}).items():
+            if not isinstance(entry_data, dict):
+                continue
+            coordinator: CarburantiDataUpdateCoordinator = entry_data.get("coordinator")  # type: ignore[assignment]
+            if coordinator is None:
+                continue
+            success = await coordinator.async_force_csv_update()
+            if success:
+                await coordinator.async_request_refresh()
+                _LOGGER.info("CSV update and refresh completed for entry %s", entry_id)
+            else:
+                _LOGGER.warning("CSV update failed for entry %s", entry_id)
+
+    async def _handle_clear_cache(call: ServiceCall) -> None:
+        _LOGGER.info("Service clear_cache triggered")
+        for entry_id, entry_data in hass.data.get(DOMAIN, {}).items():
+            if not isinstance(entry_data, dict):
+                continue
+            coordinator: CarburantiDataUpdateCoordinator = entry_data.get("coordinator")  # type: ignore[assignment]
+            if coordinator is None:
+                continue
+            await coordinator.csv_manager.async_clear_cache()
+            await coordinator.csv_manager.async_initialize()
+            await coordinator.async_request_refresh()
+            _LOGGER.info("Cache cleared and re-initialized for entry %s", entry_id)
+
+    async def _handle_compare_stations(call: ServiceCall) -> ServiceResponse:
+        _LOGGER.info("Service compare_stations triggered")
+        comparison: dict[str, Any] = {}
+        for entry_id, entry_data in hass.data.get(DOMAIN, {}).items():
+            if not isinstance(entry_data, dict):
+                continue
+            coordinator: CarburantiDataUpdateCoordinator = entry_data.get("coordinator")  # type: ignore[assignment]
+            if coordinator is None or not coordinator.data:
+                continue
+            station_info = coordinator.data.get("station_info", {})
+            station_name = station_info.get("nomeImpianto") or station_info.get("name") or entry_id
+            fuels: dict[str, Any] = {}
+            for fuel_key, fuel_info in coordinator.data.get("fuels", {}).items():
+                fuels[fuel_key] = {
+                    "price": fuel_info.get("price"),
+                    "previous_price": fuel_info.get("previous_price"),
+                    "price_changed_at": fuel_info.get("price_changed_at"),
+                    "is_self": fuel_info.get("is_self"),
+                    "last_update": fuel_info.get("last_update"),
+                }
+            comparison[entry_id] = {
+                "station_name": station_name,
+                "station_id": station_info.get("id"),
+                "brand": station_info.get("brand"),
+                "address": station_info.get("address"),
+                "fuels": fuels,
+            }
+        return {"stations": comparison}
+
+    hass.services.async_register(
+        DOMAIN, SERVICE_FORCE_CSV_UPDATE, _handle_force_csv_update,
+    )
+    hass.services.async_register(
+        DOMAIN, SERVICE_CLEAR_CACHE, _handle_clear_cache,
+    )
+    hass.services.async_register(
+        DOMAIN, SERVICE_COMPARE_STATIONS, _handle_compare_stations,
+        supports_response=SupportsResponse.ONLY,
+    )
+
+
 async def async_migrate_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> bool:
-    """Migrate old entry."""
     _LOGGER.debug("Migrating config entry from version %s", config_entry.version)
 
     if config_entry.version == 1:
-        # Remove unused config_type from entry data
         new_data = config_entry.data.copy()
         new_data.pop("config_type", None)
 
@@ -89,6 +170,13 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         entry_data = hass.data[DOMAIN].pop(entry.entry_id)
         entry_data["listener"]()
         await entry_data["coordinator"].async_shutdown()
+
+        if not hass.data[DOMAIN]:
+            hass.services.async_remove(DOMAIN, SERVICE_FORCE_CSV_UPDATE)
+            hass.services.async_remove(DOMAIN, SERVICE_CLEAR_CACHE)
+            hass.services.async_remove(DOMAIN, SERVICE_COMPARE_STATIONS)
+            hass.data.pop(_SERVICES_REGISTERED, None)
+
     return unload_ok
 
 async def async_reload_entry(hass: HomeAssistant, entry: ConfigEntry) -> None:

--- a/custom_components/osservaprezzi_carburanti/api.py
+++ b/custom_components/osservaprezzi_carburanti/api.py
@@ -26,7 +26,7 @@ _NEXT_ALLOWED_REQUEST_AT = 0.0
 async def fetch_station_data(
     hass: HomeAssistant,
     station_id: str,
-    timeout: int = 30
+    timeout: int = 30,
 ) -> dict[str, Any]:
     """Fetch station data from the API.
 
@@ -84,11 +84,8 @@ async def fetch_station_data(
                     message=f"Service error: {response.status} - {response.reason}",
                     headers=response.headers,
                 )
-    except aiohttp.ClientError:
-        raise  # Re-raise aiohttp errors as-is (ClientResponseError, ClientError, etc.)
-    except Exception as e:
-        _LOGGER.error("Unexpected error fetching station data: %s", e)
-        raise aiohttp.ClientError(f"Unexpected error: {e}")
+    except (aiohttp.ClientError, asyncio.TimeoutError):
+        raise
 
 
 async def _wait_for_request_slot(station_id: str) -> None:

--- a/custom_components/osservaprezzi_carburanti/api.py
+++ b/custom_components/osservaprezzi_carburanti/api.py
@@ -35,7 +35,7 @@ async def fetch_station_data(
     _LOGGER.debug("Fetching station data from: %s", url)
 
     try:
-        async with session.get(url, headers=DEFAULT_HEADERS, timeout=timeout) as response:
+        async with session.get(url, headers=DEFAULT_HEADERS, timeout=aiohttp.ClientTimeout(total=timeout)) as response:
             _LOGGER.debug("Station API response status: %s", response.status)
 
             if response.status == 200:

--- a/custom_components/osservaprezzi_carburanti/api.py
+++ b/custom_components/osservaprezzi_carburanti/api.py
@@ -1,13 +1,26 @@
 """API helper functions for Osservaprezzi Carburanti."""
 from __future__ import annotations
+
+import asyncio
 import logging
-import aiohttp
+import time
 from typing import Any
+
+import aiohttp
+
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
-from .const import BASE_URL, STATION_ENDPOINT, DEFAULT_HEADERS
+
+from .const import (
+    API_REQUEST_INTERVAL_SECONDS,
+    BASE_URL,
+    DEFAULT_HEADERS,
+    STATION_ENDPOINT,
+)
 
 _LOGGER = logging.getLogger(__name__)
+_REQUEST_LOCK = asyncio.Lock()
+_NEXT_ALLOWED_REQUEST_AT = 0.0
 
 
 async def fetch_station_data(
@@ -35,36 +48,60 @@ async def fetch_station_data(
     _LOGGER.debug("Fetching station data from: %s", url)
 
     try:
-        async with session.get(url, headers=DEFAULT_HEADERS, timeout=aiohttp.ClientTimeout(total=timeout)) as response:
-            _LOGGER.debug("Station API response status: %s", response.status)
+        async with _REQUEST_LOCK:
+            await _wait_for_request_slot(station_id)
+            async with session.get(
+                url,
+                headers=DEFAULT_HEADERS,
+                timeout=aiohttp.ClientTimeout(total=timeout),
+            ) as response:
+                _LOGGER.debug("Station API response status: %s", response.status)
 
-            if response.status == 200:
-                data = await response.json()
-                _LOGGER.debug("Station API response data: %s", data)
-                return data
-            elif response.status == 404:
+                if response.status == 200:
+                    data = await response.json()
+                    _LOGGER.debug("Station API response data: %s", data)
+                    return data
+                if response.status == 404:
+                    raise aiohttp.ClientResponseError(
+                        request_info=response.request_info,
+                        history=response.history,
+                        status=response.status,
+                        message=f"Station with ID {station_id} not found",
+                        headers=response.headers,
+                    )
+                if response.status == 429:
+                    raise aiohttp.ClientResponseError(
+                        request_info=response.request_info,
+                        history=response.history,
+                        status=response.status,
+                        message="Rate limit exceeded. Please try again later.",
+                        headers=response.headers,
+                    )
                 raise aiohttp.ClientResponseError(
                     request_info=response.request_info,
                     history=response.history,
                     status=response.status,
-                    message=f"Station with ID {station_id} not found"
-                )
-            elif response.status == 429:
-                raise aiohttp.ClientResponseError(
-                    request_info=response.request_info,
-                    history=response.history,
-                    status=response.status,
-                    message="Rate limit exceeded. Please try again later."
-                )
-            else:
-                raise aiohttp.ClientResponseError(
-                    request_info=response.request_info,
-                    history=response.history,
-                    status=response.status,
-                    message=f"Service error: {response.status} - {response.reason}"
+                    message=f"Service error: {response.status} - {response.reason}",
+                    headers=response.headers,
                 )
     except aiohttp.ClientError:
         raise  # Re-raise aiohttp errors as-is (ClientResponseError, ClientError, etc.)
     except Exception as e:
         _LOGGER.error("Unexpected error fetching station data: %s", e)
         raise aiohttp.ClientError(f"Unexpected error: {e}")
+
+
+async def _wait_for_request_slot(station_id: str) -> None:
+    """Serialize outbound station requests to avoid API bursts."""
+    global _NEXT_ALLOWED_REQUEST_AT
+
+    wait_time = _NEXT_ALLOWED_REQUEST_AT - time.monotonic()
+    if wait_time > 0:
+        _LOGGER.debug(
+            "Waiting %.2fs before requesting station %s to avoid API bursts",
+            wait_time,
+            station_id,
+        )
+        await asyncio.sleep(wait_time)
+
+    _NEXT_ALLOWED_REQUEST_AT = time.monotonic() + API_REQUEST_INTERVAL_SECONDS

--- a/custom_components/osservaprezzi_carburanti/config_flow.py
+++ b/custom_components/osservaprezzi_carburanti/config_flow.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
+
 import logging
 from typing import Any
-import asyncio
+
 import aiohttp
 import voluptuous as vol
 from homeassistant import config_entries
@@ -41,7 +42,7 @@ async def _validate_station(hass: HomeAssistant, station_id: str) -> dict[str, A
         raise CannotConnect(f"Connection error: {err}")
 
 
-class OsservaprezziCarburantiConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
+class OsservaprezziCarburantiConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  # type: ignore[call-arg]
     VERSION = 2
 
 

--- a/custom_components/osservaprezzi_carburanti/config_flow.py
+++ b/custom_components/osservaprezzi_carburanti/config_flow.py
@@ -91,11 +91,7 @@ class OsservaprezziCarburantiConfigFlow(config_entries.ConfigFlow, domain=DOMAIN
         """Handle the initial step - directly ask for station ID."""
         return await self._handle_station_input(user_input, "user")
 
-    async def async_step_station(
-        self, user_input: dict[str, Any] | None = None
-    ) -> FlowResult:
-        """Handle the setup of a single station."""
-        return await self._handle_station_input(user_input, "station")
+
 
 
 class OptionsFlowHandler(config_entries.OptionsFlowWithConfigEntry):

--- a/custom_components/osservaprezzi_carburanti/config_flow.py
+++ b/custom_components/osservaprezzi_carburanti/config_flow.py
@@ -5,10 +5,9 @@ import asyncio
 import aiohttp
 import voluptuous as vol
 from homeassistant import config_entries
+from homeassistant.config_entries import ConfigFlowResult
 from homeassistant.core import callback, HomeAssistant
-from homeassistant.data_entry_flow import FlowResult
 from homeassistant.exceptions import HomeAssistantError
-from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from .const import (
     DOMAIN,
     CONF_STATION_ID,
@@ -56,9 +55,9 @@ class OsservaprezziCarburantiConfigFlow(config_entries.ConfigFlow, domain=DOMAIN
 
     async def _handle_station_input(
         self, user_input: dict[str, Any] | None, step_id: str
-    ) -> FlowResult:
+    ) -> ConfigFlowResult:
         """Handle station ID input for any config flow step."""
-        errors = {}
+        errors: dict[str, str] = {}
         if user_input is not None:
             try:
                 station_id = user_input[CONF_STATION_ID]
@@ -87,7 +86,7 @@ class OsservaprezziCarburantiConfigFlow(config_entries.ConfigFlow, domain=DOMAIN
 
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
-    ) -> FlowResult:
+    ) -> ConfigFlowResult:
         """Handle the initial step - directly ask for station ID."""
         return await self._handle_station_input(user_input, "user")
 
@@ -99,9 +98,9 @@ class OptionsFlowHandler(config_entries.OptionsFlowWithConfigEntry):
 
     async def async_step_init(
         self, user_input: dict[str, Any] | None = None
-    ) -> FlowResult:
+    ) -> ConfigFlowResult:
         """Manage the options."""
-        errors = {}
+        errors: dict[str, str] = {}
         if user_input is not None:
             cron_expr = user_input[CONF_CRON_EXPRESSION]
             old_cron_expr = self.options.get(CONF_CRON_EXPRESSION, DEFAULT_CRON_EXPRESSION)

--- a/custom_components/osservaprezzi_carburanti/const.py
+++ b/custom_components/osservaprezzi_carburanti/const.py
@@ -5,7 +5,7 @@ CONF_STATION_ID = "station_id"
 
 # Options
 CONF_CRON_EXPRESSION = "cron_expression"
-DEFAULT_CRON_EXPRESSION = "30 8 * * *"  # Daily at 07:30
+DEFAULT_CRON_EXPRESSION = "30 8 * * *"  # Daily at 08:30
 
 # API
 BASE_URL = "https://carburanti.mise.gov.it/ospzApi"
@@ -90,9 +90,9 @@ ADDITIONAL_SERVICES = {
 SERVICE_ID_TO_TRANSLATION_KEY = {
     "1": "food_beverage",
     "2": "workshop",
-    "3": "camper_truck_parking",
-    "4": "camper_dump",
-    "5": "play_area",
+    "3": "parking",
+    "4": "dump_station",
+    "5": "playground",
     "6": "atm",
     "7": "disabled_access",
     "8": "wifi",

--- a/custom_components/osservaprezzi_carburanti/const.py
+++ b/custom_components/osservaprezzi_carburanti/const.py
@@ -20,56 +20,67 @@ ADDITIONAL_SERVICES = {
     "1": {
         "name": "Food&Beverage",
         "icon": "mdi:food",
+        "description": "Bar, restaurant or refreshment point",
         "image_url": "https://carburanti.mise.gov.it/ospzSearch/assets/servizi/1.gif"
     },
     "2": {
         "name": "Officina",
         "icon": "mdi:car-wrench",
+        "description": "Repair and maintenance service",
         "image_url": "https://carburanti.mise.gov.it/ospzSearch/assets/servizi/2.gif"
     },
     "3": {
         "name": "Sosta Camper/Tir",
         "icon": "mdi:truck",
+        "description": "Parking area for campers and trucks",
         "image_url": "https://carburanti.mise.gov.it/ospzSearch/assets/servizi/3.gif"
     },
     "4": {
         "name": "Scarico per camper",
         "icon": "mdi:water-pump",
+        "description": "Black/gray water dump point",
         "image_url": "https://carburanti.mise.gov.it/ospzSearch/assets/servizi/4.gif"
     },
     "5": {
         "name": "Area bambini",
         "icon": "mdi:human-child",
+        "description": "Playground for children",
         "image_url": "https://carburanti.mise.gov.it/ospzSearch/assets/servizi/5.gif"
     },
     "6": {
         "name": "Bancomat",
         "icon": "mdi:cash-multiple",
+        "description": "Automatic teller machine",
         "image_url": "https://carburanti.mise.gov.it/ospzSearch/assets/servizi/6.gif"
     },
     "7": {
         "name": "Servizi per disabili",
         "icon": "mdi:wheelchair-accessibility",
+        "description": "Services accessible for disabled people",
         "image_url": "https://carburanti.mise.gov.it/ospzSearch/assets/servizi/7.gif"
     },
     "8": {
         "name": "Wi-Fi",
         "icon": "mdi:wifi",
+        "description": "Free or paid Wi-Fi connection",
         "image_url": "https://carburanti.mise.gov.it/ospzSearch/assets/servizi/8.gif"
     },
     "9": {
         "name": "Gommista",
         "icon": "mdi:tire",
+        "description": "Tire and tire service",
         "image_url": "https://carburanti.mise.gov.it/ospzSearch/assets/servizi/9.gif"
     },
     "10": {
         "name": "Autolavaggio",
         "icon": "mdi:car-wash",
+        "description": "Car washing service",
         "image_url": "https://carburanti.mise.gov.it/ospzSearch/assets/servizi/10.gif"
     },
     "11": {
         "name": "Ricarica elettrica",
         "icon": "mdi:ev-station",
+        "description": "Charging stations for electric vehicles",
         "image_url": "https://carburanti.mise.gov.it/ospzSearch/assets/servizi/11.gif"
     }
 }
@@ -107,3 +118,9 @@ ATTR_FUEL_TYPE_NAME = "fuel_type_name"
 ATTR_IS_SELF = "is_self_service"
 ATTR_LATITUDE = "latitude"
 ATTR_LONGITUDE = "longitude"
+ATTR_PREVIOUS_PRICE = "previous_price"
+ATTR_PRICE_CHANGED_AT = "price_changed_at"
+
+SERVICE_FORCE_CSV_UPDATE = "force_csv_update"
+SERVICE_CLEAR_CACHE = "clear_cache"
+SERVICE_COMPARE_STATIONS = "compare_stations"

--- a/custom_components/osservaprezzi_carburanti/const.py
+++ b/custom_components/osservaprezzi_carburanti/const.py
@@ -10,6 +10,7 @@ DEFAULT_CRON_EXPRESSION = "30 8 * * *"  # Daily at 07:30
 # API
 BASE_URL = "https://carburanti.mise.gov.it/ospzApi"
 STATION_ENDPOINT = "/registry/servicearea/{station_id}"
+API_REQUEST_INTERVAL_SECONDS = 2
 
 # CSV data source
 CSV_URL = "https://www.mimit.gov.it/images/exportCSV/anagrafica_impianti_attivi.csv"

--- a/custom_components/osservaprezzi_carburanti/coordinator.py
+++ b/custom_components/osservaprezzi_carburanti/coordinator.py
@@ -9,7 +9,6 @@ import aiohttp
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.event import async_track_time_interval
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 from homeassistant.util import dt as dt_util
@@ -31,7 +30,6 @@ RETRY_DELAYS: list[int] = [30, 60, 120]
 class CarburantiDataUpdateCoordinator(DataUpdateCoordinator):
     def __init__(self, hass: HomeAssistant, entry: ConfigEntry) -> None:
         self.config_entry = entry
-        self.session = async_get_clientsession(hass)
         self.csv_manager = CSVStationManager(hass)
         self._csv_update_listener: Callable[[], None] | None = None
         self._previous_fuel_prices: dict[str, float | None] = {}
@@ -48,7 +46,8 @@ class CarburantiDataUpdateCoordinator(DataUpdateCoordinator):
     async def _async_update_data(self) -> dict[str, Any]:
         if not self.csv_manager.is_data_available():
             _LOGGER.info("Initializing CSV station data")
-            await self.csv_manager.async_initialize()
+            if not await self.csv_manager.async_initialize():
+                _LOGGER.warning("CSV station data initialization failed; continuing without CSV enrichment")
 
         self._snapshot_previous_prices()
         return await self._async_fetch_station_data()
@@ -104,7 +103,7 @@ class CarburantiDataUpdateCoordinator(DataUpdateCoordinator):
             if retry_after:
                 try:
                     parsed_delay = int(float(retry_after))
-                except ValueError:
+                except (TypeError, ValueError):
                     return default_delay
                 if parsed_delay > 0:
                     return parsed_delay
@@ -270,5 +269,8 @@ class CarburantiDataUpdateCoordinator(DataUpdateCoordinator):
         to trigger an immediate refresh of CSV station data.
         """
         _LOGGER.info("Forcing immediate CSV data update")
-        return await self.csv_manager.async_update_csv_data(force_update=True)
+        success = await self.csv_manager.async_update_csv_data(force_update=True)
+        if success:
+            await self.csv_manager.async_save_cached_data()
+        return success
 

--- a/custom_components/osservaprezzi_carburanti/coordinator.py
+++ b/custom_components/osservaprezzi_carburanti/coordinator.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+import asyncio
 import logging
 from datetime import datetime, timedelta
 from typing import Any, Callable
@@ -21,49 +22,67 @@ from .csv_manager import CSVStationManager
 
 _LOGGER = logging.getLogger(__name__)
 
+RETRY_DELAYS: list[int] = [30, 60, 120]
+
 class CarburantiDataUpdateCoordinator(DataUpdateCoordinator):
     def __init__(self, hass: HomeAssistant, entry: ConfigEntry) -> None:
         self.config_entry = entry
         self.session = async_get_clientsession(hass)
         self.csv_manager = CSVStationManager(hass)
         self._csv_update_listener: Callable[[], None] | None = None
+        self._previous_fuel_prices: dict[str, float | None] = {}
 
         unique_id = entry.unique_id
         super().__init__(
             hass,
             _LOGGER,
             name=f"{DOMAIN}_{unique_id}",
-            update_interval=None,  # Updates are triggered by a listener
+            update_interval=None,
         )
         self._schedule_csv_updates()
 
     async def _async_update_data(self) -> dict[str, Any]:
-        # Ensure CSV data is available
         if not self.csv_manager.is_data_available():
             _LOGGER.info("Initializing CSV station data")
             await self.csv_manager.async_initialize()
-        
+
+        self._snapshot_previous_prices()
         return await self._async_fetch_station_data()
 
+    def _snapshot_previous_prices(self) -> None:
+        if not self.data or "fuels" not in self.data:
+            return
+        for fuel_key, fuel_info in self.data["fuels"].items():
+            self._previous_fuel_prices[fuel_key] = fuel_info.get("price")
+
     async def _async_fetch_station_data(self) -> dict[str, Any]:
-        """Fetch data for a single station."""
         station_id = self.config_entry.data[CONF_STATION_ID]
-        try:
-            data = await fetch_station_data(self.hass, station_id)
-            return await self._process_station_data(data)
-        except aiohttp.ClientResponseError as err:
-            if err.status == 404:
-                _LOGGER.error("Station with ID %s not found", station_id)
-                raise UpdateFailed(f"Station with ID {station_id} not found")
-            else:
-                _LOGGER.error("Service error for station API: %s", err.status)
-                raise UpdateFailed(f"Service error: {err.status}")
-        except aiohttp.ClientError as err:
-            _LOGGER.error("Error fetching station data: %s", err)
-            raise UpdateFailed(f"Error fetching station data: {err}")
-        except Exception as err:
-            _LOGGER.error("Unexpected error fetching station data for station %s: %s", station_id, err)
-            raise UpdateFailed(f"Unexpected error fetching station data: {err}")
+        last_err: Exception | None = None
+        for attempt in range(len(RETRY_DELAYS) + 1):
+            try:
+                data = await fetch_station_data(self.hass, station_id)
+                return await self._process_station_data(data)
+            except aiohttp.ClientResponseError as err:
+                if err.status == 404:
+                    _LOGGER.error("Station with ID %s not found", station_id)
+                    raise UpdateFailed(f"Station with ID {station_id} not found")
+                last_err = err
+            except (aiohttp.ClientError, asyncio.TimeoutError) as err:
+                last_err = err
+
+            if attempt < len(RETRY_DELAYS):
+                delay = RETRY_DELAYS[attempt]
+                _LOGGER.warning(
+                    "Attempt %d/%d failed for station %s, retrying in %ds: %s",
+                    attempt + 1, len(RETRY_DELAYS) + 1, station_id, delay, last_err,
+                )
+                await asyncio.sleep(delay)
+
+        _LOGGER.error(
+            "All %d attempts failed for station %s: %s",
+            len(RETRY_DELAYS) + 1, station_id, last_err,
+        )
+        raise UpdateFailed(f"Error fetching station data after {len(RETRY_DELAYS) + 1} attempts: {last_err}")
 
 
 
@@ -74,38 +93,24 @@ class CarburantiDataUpdateCoordinator(DataUpdateCoordinator):
             _LOGGER.warning("No station ID provided for coordinate lookup")
             return None
 
-        # Convert station_id to string to handle int/str type mismatch
         station_id_str = str(station_id)
-        _LOGGER.debug("Looking for station ID: '%s' (original type: %s, as string: '%s', length: %d)",
-                     station_id, type(station_id).__name__, station_id_str, len(station_id_str))
 
-        # Try CSV data only
         csv_station = self.csv_manager.get_station_by_id(station_id_str)
         if csv_station:
             lat = csv_station.get('latitude')
             lon = csv_station.get('longitude')
             if lat is not None and lon is not None:
-                _LOGGER.debug("Found coordinates in CSV data for station %s: %s, %s", station_id_str, lat, lon)
+                _LOGGER.debug("Found coordinates for station %s: %s, %s", station_id_str, lat, lon)
                 return {
                     "latitude": float(lat),
                     "longitude": float(lon),
                     "source": "csv"
                 }
             else:
-                _LOGGER.warning("Station %s found in CSV but missing coordinates. CSV data: %s", station_id_str, csv_station)
+                _LOGGER.warning("Station %s found in CSV but missing coordinates", station_id_str)
         else:
             _LOGGER.warning("Station %s not found in CSV data", station_id_str)
 
-            # Debug: Let's see some sample station IDs from CSV to understand the format
-            if _LOGGER.isEnabledFor(logging.DEBUG):
-                sample_stations = self.csv_manager.get_sample_station_ids(5)
-                _LOGGER.debug("Sample station IDs from CSV: %s", sample_stations)
-
-                # Get detailed statistics about station IDs
-                id_stats = self.csv_manager.get_station_id_stats()
-                _LOGGER.debug("Station ID statistics: %s", id_stats)
-
-        _LOGGER.error("No coordinates found for station %s in CSV data", station_id_str)
         return None
 
 
@@ -173,18 +178,26 @@ class CarburantiDataUpdateCoordinator(DataUpdateCoordinator):
             "opening_hours": data.get("orariapertura", []),
             "last_update": dt_util.now().isoformat(),
         }
+        now_iso = dt_util.now().isoformat()
         for fuel in data.get("fuels", []):
             fuel_id = fuel.get("fuelId")
             fuel_name = fuel.get("name", "Unknown")
             service_type = "self" if fuel.get("isSelf") else "servito"
             fuel_key = f"{fuel_name}_{service_type}"
+            new_price = fuel.get("price")
+            previous_price = self._previous_fuel_prices.get(fuel_key)
+            price_changed_at: str | None = None
+            if new_price != previous_price and previous_price is not None:
+                price_changed_at = now_iso
             processed_data["fuels"][fuel_key] = {
-                "price": fuel.get("price"),
+                "price": new_price,
                 "last_update": self._parse_iso_datetime(fuel.get("insertDate")),
                 "validity_date": self._parse_iso_datetime(fuel.get("validityDate")),
                 "fuel_id": fuel_id,
                 "is_self": fuel.get("isSelf"),
                 "service_area_id": fuel.get("serviceAreaId"),
+                "previous_price": previous_price,
+                "price_changed_at": price_changed_at,
             }
         return processed_data
 

--- a/custom_components/osservaprezzi_carburanti/coordinator.py
+++ b/custom_components/osservaprezzi_carburanti/coordinator.py
@@ -1,21 +1,25 @@
 from __future__ import annotations
+
 import asyncio
 import logging
 from datetime import datetime, timedelta
 from typing import Any, Callable
+
 import aiohttp
+
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.event import async_track_time_interval
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 from homeassistant.util import dt as dt_util
+
 from .const import (
-    DOMAIN,
-    CONF_STATION_ID,
     ATTR_LATITUDE,
     ATTR_LONGITUDE,
+    CONF_STATION_ID,
     CSV_UPDATE_INTERVAL,
+    DOMAIN,
 )
 from .api import fetch_station_data
 from .csv_manager import CSVStationManager
@@ -71,18 +75,49 @@ class CarburantiDataUpdateCoordinator(DataUpdateCoordinator):
                 last_err = err
 
             if attempt < len(RETRY_DELAYS):
-                delay = RETRY_DELAYS[attempt]
+                delay = self._get_retry_delay(last_err, RETRY_DELAYS[attempt])
                 _LOGGER.warning(
                     "Attempt %d/%d failed for station %s, retrying in %ds: %s",
                     attempt + 1, len(RETRY_DELAYS) + 1, station_id, delay, last_err,
                 )
                 await asyncio.sleep(delay)
 
+        if self.data and self._is_transient_error(last_err):
+            _LOGGER.warning(
+                "Keeping last known data for station %s after transient update failure: %s",
+                station_id,
+                last_err,
+            )
+            return self.data
+
         _LOGGER.error(
             "All %d attempts failed for station %s: %s",
             len(RETRY_DELAYS) + 1, station_id, last_err,
         )
         raise UpdateFailed(f"Error fetching station data after {len(RETRY_DELAYS) + 1} attempts: {last_err}")
+
+    @staticmethod
+    def _get_retry_delay(err: Exception | None, default_delay: int) -> int:
+        """Return the retry delay, preferring Retry-After when available."""
+        if isinstance(err, aiohttp.ClientResponseError) and err.status == 429 and err.headers:
+            retry_after = err.headers.get("Retry-After")
+            if retry_after:
+                try:
+                    parsed_delay = int(float(retry_after))
+                except ValueError:
+                    return default_delay
+                if parsed_delay > 0:
+                    return parsed_delay
+        return default_delay
+
+    @staticmethod
+    def _is_transient_error(err: Exception | None) -> bool:
+        """Return True for recoverable request failures."""
+        if isinstance(err, asyncio.TimeoutError):
+            return True
+        if isinstance(err, aiohttp.ClientResponseError):
+            return err.status != 404
+        return isinstance(err, aiohttp.ClientError)
 
 
 

--- a/custom_components/osservaprezzi_carburanti/cron_helper.py
+++ b/custom_components/osservaprezzi_carburanti/cron_helper.py
@@ -1,11 +1,15 @@
 from __future__ import annotations
 from datetime import datetime, timedelta
-from typing import Optional
+from typing import TYPE_CHECKING, Optional
 from homeassistant.util import dt as dt_util
-try:
+
+if TYPE_CHECKING:
     from cronsim import CronSim
-except ImportError:
-    CronSim = None
+else:
+    try:
+        from cronsim import CronSim
+    except ImportError:
+        CronSim = None  # type: ignore[assignment,misc]
 
 def validate_cron_expression(cron_expr: str) -> bool:
     """Validate a cron expression using CronSim."""

--- a/custom_components/osservaprezzi_carburanti/cron_helper.py
+++ b/custom_components/osservaprezzi_carburanti/cron_helper.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
+
 from datetime import datetime, timedelta
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING
+
 from homeassistant.util import dt as dt_util
 
 if TYPE_CHECKING:
@@ -21,7 +23,7 @@ def validate_cron_expression(cron_expr: str) -> bool:
     except Exception:
         return False
 
-def get_next_run_time(cron_expr: str, base_time: Optional[datetime] = None) -> datetime:
+def get_next_run_time(cron_expr: str, base_time: datetime | None = None) -> datetime:
     """Get the next run time for a cron expression."""
     if CronSim is None:
         raise ImportError("cronsim is required for cron scheduling")

--- a/custom_components/osservaprezzi_carburanti/csv_manager.py
+++ b/custom_components/osservaprezzi_carburanti/csv_manager.py
@@ -87,7 +87,7 @@ class CSVStationManager:
                 "Accept": "text/csv,application/csv,text/plain,*/*",
             }
 
-            async with self.session.get(CSV_URL, headers=headers, timeout=60) as response:
+            async with self.session.get(CSV_URL, headers=headers, timeout=aiohttp.ClientTimeout(total=60)) as response:
                 if response.status != 200:
                     _LOGGER.error("Failed to download CSV: HTTP %s", response.status)
                     return False
@@ -151,14 +151,14 @@ class CSVStationManager:
                     _LOGGER.warning("Column '%s' not found in CSV", csv_col)
                     col_indices[internal_col] = -1
 
-            stations_cache = {}
+            stations_cache: dict[str, dict[str, Any]] = {}
             for line_num, line in enumerate(lines[2:], 3):
                 try:
                     values = [v.strip().strip('"') for v in line.split(separator)]
                     if len(values) < len(headers):
                         continue
 
-                    station_data = {}
+                    station_data: dict[str, Any] = {}
 
                     for csv_col, internal_col in CSV_COLUMNS.items():
                         idx = col_indices.get(internal_col, -1)
@@ -279,9 +279,9 @@ class CSVStationManager:
         if not self._stations_cache:
             return {"total": 0, "formats": {}}
         
-        id_lengths = {}
-        id_types = {}
-        sample_ids = []
+        id_lengths: dict[int, int] = {}
+        id_types: dict[str, int] = {}
+        sample_ids: list[str] = []
         
         for station_id in list(self._stations_cache.keys())[:100]:
             length = len(station_id)

--- a/custom_components/osservaprezzi_carburanti/csv_manager.py
+++ b/custom_components/osservaprezzi_carburanti/csv_manager.py
@@ -7,7 +7,7 @@ import shutil
 import asyncio
 import aiohttp
 from datetime import datetime, timedelta
-from typing import Any, Dict, List, Optional
+from typing import Any
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.util import dt as dt_util
@@ -47,8 +47,8 @@ class CSVStationManager:
         """Initialize the CSV manager."""
         self.hass = hass
         self.session = async_get_clientsession(hass)
-        self._stations_cache: Dict[str, Dict[str, Any]] = {}
-        self._last_update: Optional[datetime] = None
+        self._stations_cache: dict[str, dict[str, Any]] = {}
+        self._last_update: datetime | None = None
         self._csv_path = hass.config.path(".storage", f"{DOMAIN}_stations.csv")
         self._cache_path = hass.config.path(".storage", f"{DOMAIN}_cache.json")
         self._detected_separator = '|'  # Default to new format (pipe)
@@ -132,35 +132,27 @@ class CSVStationManager:
         self._detected_separator = separator
         return separator
 
-    def _parse_csv_data_sync(self, csv_content: str) -> bool:
-        """Parse CSV content and populate station cache (synchronous helper)."""
+    def _parse_csv_lines(self, lines: list[str]) -> bool:
+        """Parse CSV lines and populate station cache (synchronous helper)."""
         try:
-            # Parse CSV content
-            lines = csv_content.splitlines()
-            if len(lines) < 3:  # Need at least extraction date, headers, and one data row
+            if len(lines) < 3:
                 _LOGGER.error("CSV file has insufficient data")
                 return False
 
-            # Skip extraction date line (line 0) and use headers from line 1
             header_line = lines[1]
-
-            # Detect separator automatically
             separator = self._detect_separator(header_line)
             headers = [h.strip().strip('"') for h in header_line.split(separator)]
 
-            # Find column indices
             col_indices = {}
             for csv_col, internal_col in CSV_COLUMNS.items():
                 try:
                     col_indices[internal_col] = headers.index(csv_col)
-                    _LOGGER.debug("Found column '%s' -> '%s' at index %d", csv_col, internal_col, col_indices[internal_col])
                 except ValueError:
                     _LOGGER.warning("Column '%s' not found in CSV", csv_col)
                     col_indices[internal_col] = -1
 
-            # Parse station data
             stations_cache = {}
-            for line_num, line in enumerate(lines[2:], 3):  # Start from line 3 (after extraction date and headers)
+            for line_num, line in enumerate(lines[2:], 3):
                 try:
                     values = [v.strip().strip('"') for v in line.split(separator)]
                     if len(values) < len(headers):
@@ -168,16 +160,13 @@ class CSVStationManager:
 
                     station_data = {}
 
-                    # Extract data using column mapping
                     for csv_col, internal_col in CSV_COLUMNS.items():
                         idx = col_indices.get(internal_col, -1)
                         if idx >= 0 and idx < len(values):
                             value = values[idx]
 
-                            # Convert coordinates to float
                             if internal_col in ['latitude', 'longitude']:
                                 try:
-                                    # Handle Italian decimal format (comma as decimal separator)
                                     if ',' in value:
                                         value = value.replace(',', '.')
                                     station_data[internal_col] = float(value)
@@ -186,84 +175,6 @@ class CSVStationManager:
                             else:
                                 station_data[internal_col] = value if value else None
 
-                    # Only include stations with valid coordinates
-                    station_id = station_data.get('id')
-                    if station_id and station_data.get('latitude') and station_data.get('longitude'):
-                        stations_cache[station_id] = station_data
-
-                except Exception as err:
-                    _LOGGER.warning("Error parsing CSV line %d: %s", line_num, err)
-                    continue
-
-            self._stations_cache = stations_cache
-            _LOGGER.info("Parsed %d stations from CSV", len(stations_cache))
-            return True
-
-        except Exception as err:
-            _LOGGER.error("Error parsing CSV data: %s", err)
-            return False
-
-    async def _parse_csv_data(self, csv_content: str) -> bool:
-        """Parse CSV content and populate station cache."""
-        return await self.hass.async_add_executor_job(self._parse_csv_data_sync, csv_content)
-
-    def _parse_csv_data_sync_from_file(self) -> bool:
-        """Parse CSV from disk file and populate station cache (synchronous helper)."""
-        try:
-            # Read file line-by-line to reduce memory pressure
-            with open(self._csv_path, 'r', encoding='utf-8') as f:
-                lines = [line.rstrip('\n') for line in f]
-
-            if len(lines) < 3:  # Need at least extraction date, headers, and one data row
-                _LOGGER.error("CSV file has insufficient data")
-                return False
-
-            # Skip extraction date line (line 0) and use headers from line 1
-            header_line = lines[1]
-
-            # Detect separator automatically
-            separator = self._detect_separator(header_line)
-            headers = [h.strip().strip('"') for h in header_line.split(separator)]
-
-            # Find column indices
-            col_indices = {}
-            for csv_col, internal_col in CSV_COLUMNS.items():
-                try:
-                    col_indices[internal_col] = headers.index(csv_col)
-                    _LOGGER.debug("Found column '%s' -> '%s' at index %d", csv_col, internal_col, col_indices[internal_col])
-                except ValueError:
-                    _LOGGER.warning("Column '%s' not found in CSV", csv_col)
-                    col_indices[internal_col] = -1
-
-            # Parse station data
-            stations_cache = {}
-            for line_num, line in enumerate(lines[2:], 3):  # Start from line 3 (after extraction date and headers)
-                try:
-                    values = [v.strip().strip('"') for v in line.split(separator)]
-                    if len(values) < len(headers):
-                        continue
-
-                    station_data = {}
-
-                    # Extract data using column mapping
-                    for csv_col, internal_col in CSV_COLUMNS.items():
-                        idx = col_indices.get(internal_col, -1)
-                        if idx >= 0 and idx < len(values):
-                            value = values[idx]
-
-                            # Convert coordinates to float
-                            if internal_col in ['latitude', 'longitude']:
-                                try:
-                                    # Handle Italian decimal format (comma as decimal separator)
-                                    if ',' in value:
-                                        value = value.replace(',', '.')
-                                    station_data[internal_col] = float(value)
-                                except (ValueError, TypeError):
-                                    station_data[internal_col] = None
-                            else:
-                                station_data[internal_col] = value if value else None
-
-                    # Only include stations with valid coordinates
                     station_id = station_data.get('id')
                     if station_id and station_data.get('latitude') and station_data.get('longitude'):
                         stations_cache[station_id] = station_data
@@ -282,7 +193,11 @@ class CSVStationManager:
 
     async def _parse_csv_data_from_file(self) -> bool:
         """Parse CSV from disk and populate station cache."""
-        return await self.hass.async_add_executor_job(self._parse_csv_data_sync_from_file)
+        def _read_and_parse() -> bool:
+            with open(self._csv_path, 'r', encoding='utf-8') as f:
+                lines = [line.rstrip('\n') for line in f]
+            return self._parse_csv_lines(lines)
+        return await self.hass.async_add_executor_job(_read_and_parse)
     
     async def async_load_cached_data(self) -> bool:
         """Load cached station data from local file."""
@@ -350,16 +265,16 @@ class CSVStationManager:
             _LOGGER.error("Error saving cached data: %s", err)
             return False
     
-    def get_station_by_id(self, station_id: str) -> Optional[Dict[str, Any]]:
+    def get_station_by_id(self, station_id: str) -> dict[str, Any] | None:
         """Get station data by ID."""
         return self._stations_cache.get(station_id)
     
-    def get_sample_station_ids(self, count: int = 5) -> List[str]:
+    def get_sample_station_ids(self, count: int = 5) -> list[str]:
         """Get a sample of station IDs for debugging."""
         station_ids = list(self._stations_cache.keys())
         return station_ids[:count]
     
-    def get_station_id_stats(self) -> Dict[str, Any]:
+    def get_station_id_stats(self) -> dict[str, Any]:
         """Get statistics about station ID formats."""
         if not self._stations_cache:
             return {"total": 0, "formats": {}}
@@ -368,11 +283,10 @@ class CSVStationManager:
         id_types = {}
         sample_ids = []
         
-        for station_id in list(self._stations_cache.keys())[:100]:  # Sample first 100
+        for station_id in list(self._stations_cache.keys())[:100]:
             length = len(station_id)
             id_lengths[length] = id_lengths.get(length, 0) + 1
             
-            # Check if ID is numeric
             if station_id.isdigit():
                 id_types["numeric"] = id_types.get("numeric", 0) + 1
             else:
@@ -388,7 +302,7 @@ class CSVStationManager:
             "sample_ids": sample_ids
         }
     
-    def _get_all_stations(self) -> Dict[str, Dict[str, Any]]:
+    def _get_all_stations(self) -> dict[str, dict[str, Any]]:
         """Get all cached stations."""
         return self._stations_cache.copy()
 
@@ -396,7 +310,7 @@ class CSVStationManager:
         """Check if station data is available."""
         return len(self._stations_cache) > 0
 
-    def _get_last_update(self) -> Optional[datetime]:
+    def _get_last_update(self) -> datetime | None:
         """Get last update timestamp."""
         return self._last_update
     

--- a/custom_components/osservaprezzi_carburanti/geo_location.py
+++ b/custom_components/osservaprezzi_carburanti/geo_location.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+import logging
+from homeassistant.components.geo_location import GeoLocationEntity
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity import DeviceInfo
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+from .const import (
+    DOMAIN,
+    CONF_STATION_ID,
+    ATTR_LATITUDE,
+    ATTR_LONGITUDE,
+)
+from .coordinator import CarburantiDataUpdateCoordinator
+
+_LOGGER = logging.getLogger(__name__)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
+) -> None:
+    coordinator: CarburantiDataUpdateCoordinator = hass.data[DOMAIN][entry.entry_id]["coordinator"]
+    async_add_entities([StationGeoLocation(coordinator, entry)], update_before_add=True)
+
+
+class StationGeoLocation(CoordinatorEntity, GeoLocationEntity):
+    _attr_icon = "mdi:gas-station"
+    _attr_source = DOMAIN
+    _attr_translation_key = "station_geolocation"
+
+    def __init__(self, coordinator: CarburantiDataUpdateCoordinator, entry: ConfigEntry) -> None:
+        super().__init__(coordinator)
+        self._station_id = entry.data[CONF_STATION_ID]
+        self._attr_unique_id = f"{self._station_id}_geolocation"
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        station_info = self.coordinator.data.get("station_info", {}) if self.coordinator.data else {}
+        return DeviceInfo(
+            identifiers={(DOMAIN, self._station_id)},
+            name=station_info.get("name"),
+            manufacturer=station_info.get("brand"),
+            model="Area di Servizio",
+        )
+
+    @property
+    def source(self) -> str:
+        return DOMAIN
+
+    @property
+    def latitude(self) -> float | None:
+        if not self.coordinator.data or "station_info" not in self.coordinator.data:
+            return None
+        return self.coordinator.data["station_info"].get(ATTR_LATITUDE)
+
+    @property
+    def longitude(self) -> float | None:
+        if not self.coordinator.data or "station_info" not in self.coordinator.data:
+            return None
+        return self.coordinator.data["station_info"].get(ATTR_LONGITUDE)
+
+    @property
+    def state(self) -> str:
+        if not self.coordinator.data or "station_info" not in self.coordinator.data:
+            return ""
+        station_info = self.coordinator.data["station_info"]
+        return station_info.get("nomeImpianto") or station_info.get("name") or ""
+
+    @property
+    def available(self) -> bool:
+        if not self.coordinator.data or "station_info" not in self.coordinator.data:
+            return False
+        station_info = self.coordinator.data["station_info"]
+        return (station_info.get(ATTR_LATITUDE) is not None and
+                station_info.get(ATTR_LONGITUDE) is not None)

--- a/custom_components/osservaprezzi_carburanti/geo_location.py
+++ b/custom_components/osservaprezzi_carburanti/geo_location.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 import logging
-from homeassistant.components.geo_location import GeoLocationEntity
+from homeassistant.components.geo_location import GeolocationEvent
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity import DeviceInfo
@@ -24,10 +24,11 @@ async def async_setup_entry(
     async_add_entities([StationGeoLocation(coordinator, entry)], update_before_add=True)
 
 
-class StationGeoLocation(CoordinatorEntity, GeoLocationEntity):
+class StationGeoLocation(CoordinatorEntity, GeolocationEvent):
     _attr_icon = "mdi:gas-station"
     _attr_source = DOMAIN
     _attr_translation_key = "station_geolocation"
+    _attr_distance = None
 
     def __init__(self, coordinator: CarburantiDataUpdateCoordinator, entry: ConfigEntry) -> None:
         super().__init__(coordinator)
@@ -61,11 +62,11 @@ class StationGeoLocation(CoordinatorEntity, GeoLocationEntity):
         return self.coordinator.data["station_info"].get(ATTR_LONGITUDE)
 
     @property
-    def state(self) -> str:
+    def name(self) -> str | None:
         if not self.coordinator.data or "station_info" not in self.coordinator.data:
-            return ""
+            return None
         station_info = self.coordinator.data["station_info"]
-        return station_info.get("nomeImpianto") or station_info.get("name") or ""
+        return station_info.get("nomeImpianto") or station_info.get("name")
 
     @property
     def available(self) -> bool:

--- a/custom_components/osservaprezzi_carburanti/sensor.py
+++ b/custom_components/osservaprezzi_carburanti/sensor.py
@@ -120,7 +120,7 @@ async def async_setup_entry(
     """Set up the sensor platform based on config type."""
     coordinator: CarburantiDataUpdateCoordinator = hass.data[DOMAIN][entry.entry_id]["coordinator"]
     
-    sensors = []
+    sensors: list[SensorEntity | BinarySensorEntity] = []
     if coordinator.data:
         # Station-based sensors
         for fuel_key in coordinator.data.get("fuels", {}):
@@ -663,7 +663,7 @@ class StationNextChangeSensor(CoordinatorEntity, SensorEntity):
     def extra_state_attributes(self) -> dict[str, Any]:
         """Return additional state attributes."""
         change_type, change_time = self._get_next_change()
-        attributes = {
+        attributes: dict[str, Any] = {
             "change_type": change_type,
             "next_change_time": change_time.isoformat() if change_time else None,
             "last_updated": dt_util.now().isoformat(),

--- a/custom_components/osservaprezzi_carburanti/sensor.py
+++ b/custom_components/osservaprezzi_carburanti/sensor.py
@@ -434,6 +434,7 @@ class StationLocationSensor(CoordinatorEntity, SensorEntity):
 
 class StationOpenClosedBinarySensor(CoordinatorEntity, BinarySensorEntity):
     """Binary sensor indicating if the station is currently open."""
+    _attr_has_entity_name = True
     _attr_icon = "mdi:storefront"
     _attr_translation_key = "station_open_closed"
 
@@ -506,6 +507,7 @@ class StationOpenClosedBinarySensor(CoordinatorEntity, BinarySensorEntity):
 
 class StationNextChangeSensor(CoordinatorEntity, SensorEntity):
     """Sensor indicating when the station will next open or close."""
+    _attr_has_entity_name = True
     _attr_icon = "mdi:clock-time-eight"
     _attr_translation_key = "next_change"
 
@@ -686,6 +688,7 @@ class StationNextChangeSensor(CoordinatorEntity, SensorEntity):
 class StationServiceBinarySensor(CoordinatorEntity, BinarySensorEntity):
     """Representation of a binary sensor for a specific station service."""
     _attr_entity_category = EntityCategory.DIAGNOSTIC
+    _attr_has_entity_name = True
 
     def __init__(self, coordinator: CarburantiDataUpdateCoordinator, entry: ConfigEntry, service_id: str, service_info: dict) -> None:
         """Initialize the service binary sensor."""
@@ -697,8 +700,8 @@ class StationServiceBinarySensor(CoordinatorEntity, BinarySensorEntity):
         # Set unique_id, icon, and translation key from service info
         self._attr_unique_id = f"{self._station_id}_service_{service_id}"
         self._attr_icon = service_info["icon"]
-        # Use translation key for entity name localization
-        self._attr_translation_key = f"service.{SERVICE_ID_TO_TRANSLATION_KEY.get(service_id, service_id)}"
+        self._attr_name = service_info["name"]
+        self._attr_translation_key = SERVICE_ID_TO_TRANSLATION_KEY.get(service_id, service_id)
 
     @property
     def device_info(self) -> DeviceInfo:

--- a/custom_components/osservaprezzi_carburanti/sensor.py
+++ b/custom_components/osservaprezzi_carburanti/sensor.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 import logging
-from datetime import datetime, time, timedelta
+from datetime import date, datetime, time, timedelta
 from typing import Any
 from homeassistant.components.sensor import SensorEntity, SensorStateClass
 from homeassistant.components.binary_sensor import BinarySensorEntity
@@ -23,12 +23,48 @@ from .const import (
     ATTR_VALIDITY_DATE,
     ATTR_LATITUDE,
     ATTR_LONGITUDE,
+    ATTR_PREVIOUS_PRICE,
+    ATTR_PRICE_CHANGED_AT,
     ADDITIONAL_SERVICES,
     SERVICE_ID_TO_TRANSLATION_KEY,
 )
 from .coordinator import CarburantiDataUpdateCoordinator
 
 _LOGGER = logging.getLogger(__name__)
+
+HOLIDAY_SCHEDULE_ID = 8
+
+
+def _is_italian_holiday(check_date: date) -> bool:
+    """Check if a date is an Italian national public holiday."""
+    fixed_holidays = {
+        (1, 1), (1, 6), (4, 25), (5, 1), (6, 2),
+        (8, 15), (11, 1), (12, 8), (12, 25), (12, 26),
+    }
+    if (check_date.month, check_date.day) in fixed_holidays:
+        return True
+    easter = _compute_easter(check_date.year)
+    easter_monday = easter + timedelta(days=1)
+    return check_date in (easter, easter_monday)
+
+
+def _compute_easter(year: int) -> date:
+    """Compute Easter Sunday using the Anonymous Gregorian algorithm."""
+    a = year % 19
+    b = year // 100
+    c = year % 100
+    d = b // 4
+    e = b % 4
+    f = (b + 8) // 25
+    g = (b - f + 1) // 3
+    h = (19 * a + b - d - g + 15) % 30
+    i = c // 4
+    k = c % 4
+    l = (32 + 2 * e + 2 * i - h - k) % 7
+    m = (a + 11 * h + 22 * l) // 451
+    month = (h + l - 7 * m + 114) // 31
+    day = ((h + l - 7 * m + 114) % 31) + 1
+    return date(year, month, day)
 
 
 def _parse_time(time_str: str | None) -> time | None:
@@ -200,6 +236,44 @@ def _get_fuel_icon(fuel_name: str) -> str:
         return "mdi:currency-eur"
 
 
+def _find_schedule_for_day(
+    opening_hours: list[dict], weekday: int, check_date: date
+) -> dict | None:
+    """Find the schedule entry for a given weekday, considering holidays."""
+    if _is_italian_holiday(check_date):
+        for day in opening_hours:
+            if day.get("giornoSettimanaId") == HOLIDAY_SCHEDULE_ID:
+                return day
+    for day in opening_hours:
+        if day.get("giornoSettimanaId") == weekday:
+            return day
+    return None
+
+
+def _is_schedule_open(schedule: dict, current_time: time) -> bool:
+    """Check if a station is open based on a schedule entry and current time."""
+    if schedule.get("flagOrarioContinuato"):
+        open_time = _parse_time(schedule.get("oraAperturaOrarioContinuato"))
+        close_time = _parse_time(schedule.get("oraChiusuraOrarioContinuato"))
+        if open_time and close_time:
+            if open_time <= close_time:
+                return open_time <= current_time <= close_time
+            else:
+                return current_time >= open_time or current_time <= close_time
+    else:
+        morning_open = _parse_time(schedule.get("oraAperturaMattina"))
+        morning_close = _parse_time(schedule.get("oraChiusuraMattina"))
+        afternoon_open = _parse_time(schedule.get("oraAperturaPomeriggio"))
+        afternoon_close = _parse_time(schedule.get("oraChiusuraPomeriggio"))
+        if morning_open and morning_close:
+            if morning_open <= current_time <= morning_close:
+                return True
+        if afternoon_open and afternoon_close:
+            if afternoon_open <= current_time <= afternoon_close:
+                return True
+    return False
+
+
 class OsservaprezziStationSensor(CoordinatorEntity, SensorEntity):
     """Representation of a single fuel price for a specific station."""
     _attr_state_class = SensorStateClass.MEASUREMENT
@@ -252,7 +326,8 @@ class OsservaprezziStationSensor(CoordinatorEntity, SensorEntity):
             ATTR_STATION_NAME: station_info.get("name"),
             ATTR_STATION_ADDRESS: station_info.get("address"),
             ATTR_STATION_BRAND: station_info.get("brand"),
-            # Remove lat/lon to prevent multiple map markers
+            ATTR_PREVIOUS_PRICE: fuel_info.get("previous_price"),
+            ATTR_PRICE_CHANGED_AT: fuel_info.get("price_changed_at"),
         }
 
 class StationInfoSensor(CoordinatorEntity, SensorEntity):
@@ -389,60 +464,24 @@ class StationOpenClosedBinarySensor(CoordinatorEntity, BinarySensorEntity):
         if not opening_hours:
             return False
 
-        # Get current time in Italy timezone
         now = dt_util.now()
-        current_weekday = now.weekday() + 1  # Convert to 1-7 (Monday=1)
+        current_weekday = now.weekday() + 1
         current_time = now.time()
-        
-        # Find today's schedule
-        today_schedule = None
-        for day in opening_hours:
-            if day.get("giornoSettimanaId") == current_weekday:
-                today_schedule = day
-                break
-        
+
+        today_schedule = _find_schedule_for_day(
+            opening_hours, current_weekday, now.date()
+        )
+
         if not today_schedule:
             return False
-        
-        # Check if closed today
+
         if today_schedule.get("flagChiusura"):
             return False
-        
-        # Check if 24/7
+
         if today_schedule.get("flagH24"):
             return True
-        
-        # Check continuous hours
-        if today_schedule.get("flagOrarioContinuato"):
-            open_time = _parse_time(today_schedule.get("oraAperturaOrarioContinuato"))
-            close_time = _parse_time(today_schedule.get("oraChiusuraOrarioContinuato"))
-            
-            if open_time and close_time:
-                if open_time <= close_time:
-                    # Same day (e.g., 08:00-20:00)
-                    return open_time <= current_time <= close_time
-                else:
-                    # Overnight (e.g., 22:00-06:00)
-                    return current_time >= open_time or current_time <= close_time
-        
-        # Check split hours (morning + afternoon)
-        else:
-            morning_open = _parse_time(today_schedule.get("oraAperturaMattina"))
-            morning_close = _parse_time(today_schedule.get("oraChiusuraMattina"))
-            afternoon_open = _parse_time(today_schedule.get("oraAperturaPomeriggio"))
-            afternoon_close = _parse_time(today_schedule.get("oraChiusuraPomeriggio"))
-            
-            # Check morning slot
-            if morning_open and morning_close:
-                if morning_open <= current_time <= morning_close:
-                    return True
-            
-            # Check afternoon slot
-            if afternoon_open and afternoon_close:
-                if afternoon_open <= current_time <= afternoon_close:
-                    return True
-        
-        return False
+
+        return _is_schedule_open(today_schedule, current_time)
 
     @property
     def is_on(self) -> bool:
@@ -503,67 +542,25 @@ class StationNextChangeSensor(CoordinatorEntity, SensorEntity):
         if not opening_hours:
             return "no_schedule", None
 
-        # Check if 24/7
         for day in opening_hours:
             if day.get("flagH24"):
                 return "always_open", None
 
         now = dt_util.now()
-        current_weekday = now.weekday() + 1  # Convert to 1-7 (Monday=1)
+        current_weekday = now.weekday() + 1
         current_time = now.time()
 
-        # Find today's schedule
-        today_schedule = None
-        for day in opening_hours:
-            if day.get("giornoSettimanaId") == current_weekday:
-                today_schedule = day
-                break
+        today_schedule = _find_schedule_for_day(
+            opening_hours, current_weekday, now.date()
+        )
 
         if not today_schedule or today_schedule.get("flagChiusura"):
-            # Station is closed today, find next opening
             return self._find_next_opening(opening_hours, now)
 
-        # Check if currently open
-        is_open = self._is_currently_open(today_schedule, current_time)
-
-        if is_open:
-            # Find next closing time
+        if _is_schedule_open(today_schedule, current_time):
             return self._find_next_closing(today_schedule, now)
         else:
-            # Find next opening time
             return self._find_next_opening(opening_hours, now)
-
-    def _is_currently_open(self, schedule: dict, current_time: time) -> bool:
-        """Check if station is currently open based on schedule."""
-        # Check continuous hours
-        if schedule.get("flagOrarioContinuato"):
-            open_time = _parse_time(schedule.get("oraAperturaOrarioContinuato"))
-            close_time = _parse_time(schedule.get("oraChiusuraOrarioContinuato"))
-            
-            if open_time and close_time:
-                if open_time <= close_time:
-                    return open_time <= current_time <= close_time
-                else:
-                    return current_time >= open_time or current_time <= close_time
-        
-        # Check split hours
-        else:
-            morning_open = _parse_time(schedule.get("oraAperturaMattina"))
-            morning_close = _parse_time(schedule.get("oraChiusuraMattina"))
-            afternoon_open = _parse_time(schedule.get("oraAperturaPomeriggio"))
-            afternoon_close = _parse_time(schedule.get("oraChiusuraPomeriggio"))
-            
-            # Check morning slot
-            if morning_open and morning_close:
-                if morning_open <= current_time <= morning_close:
-                    return True
-            
-            # Check afternoon slot
-            if afternoon_open and afternoon_close:
-                if afternoon_open <= current_time <= afternoon_close:
-                    return True
-        
-        return False
 
     def _find_next_closing(self, schedule: dict, now: datetime) -> tuple[str, datetime | None]:
         """Find the next closing time for today."""
@@ -621,36 +618,31 @@ class StationNextChangeSensor(CoordinatorEntity, SensorEntity):
         """Find the next opening time."""
         current_weekday = now.weekday() + 1
 
-        # Check remaining time today
         for day_offset in range(7):
             check_weekday = (current_weekday + day_offset - 1) % 7 + 1
             check_date = now + timedelta(days=day_offset)
 
-            for day in opening_hours:
-                if day.get("giornoSettimanaId") == check_weekday:
-                    if day.get("flagChiusura") or day.get("flagNonComunicato"):
-                        continue
+            day = _find_schedule_for_day(opening_hours, check_weekday, check_date.date())
+            if day is None:
+                continue
+            if day.get("flagChiusura") or day.get("flagNonComunicato"):
+                continue
 
-                    # Check continuous hours
-                    if day.get("flagOrarioContinuato"):
-                        open_time = _parse_time(day.get("oraAperturaOrarioContinuato"))
-                        open_datetime = StationNextChangeSensor._make_open_datetime(open_time, day_offset, now, check_date)
-                        if open_datetime:
-                            return "opens_at", open_datetime
+            if day.get("flagOrarioContinuato"):
+                open_time = _parse_time(day.get("oraAperturaOrarioContinuato"))
+                open_datetime = StationNextChangeSensor._make_open_datetime(open_time, day_offset, now, check_date)
+                if open_datetime:
+                    return "opens_at", open_datetime
+            else:
+                morning_open = _parse_time(day.get("oraAperturaMattina"))
+                open_datetime = StationNextChangeSensor._make_open_datetime(morning_open, day_offset, now, check_date)
+                if open_datetime:
+                    return "opens_at", open_datetime
 
-                    # Check split hours
-                    else:
-                        # Check morning opening
-                        morning_open = _parse_time(day.get("oraAperturaMattina"))
-                        open_datetime = StationNextChangeSensor._make_open_datetime(morning_open, day_offset, now, check_date)
-                        if open_datetime:
-                            return "opens_at", open_datetime
-
-                        # Check afternoon opening
-                        afternoon_open = _parse_time(day.get("oraAperturaPomeriggio"))
-                        open_datetime = StationNextChangeSensor._make_open_datetime(afternoon_open, day_offset, now, check_date)
-                        if open_datetime:
-                            return "opens_at", open_datetime
+                afternoon_open = _parse_time(day.get("oraAperturaPomeriggio"))
+                open_datetime = StationNextChangeSensor._make_open_datetime(afternoon_open, day_offset, now, check_date)
+                if open_datetime:
+                    return "opens_at", open_datetime
 
         return "no_opening", None
 

--- a/custom_components/osservaprezzi_carburanti/sensor.py
+++ b/custom_components/osservaprezzi_carburanti/sensor.py
@@ -498,10 +498,10 @@ class StationOpenClosedBinarySensor(CoordinatorEntity, BinarySensorEntity):
             "last_updated": dt_util.now().isoformat(),
         }
 
-    async def async_update(self) -> None:
-        """Update the sensor and clear cache."""
-        await super().async_update()
+    def _handle_coordinator_update(self) -> None:
+        """Clear cached state after coordinator updates."""
         self._cached_is_open = None
+        super()._handle_coordinator_update()
 
 
 class StationNextChangeSensor(CoordinatorEntity, SensorEntity):
@@ -677,10 +677,10 @@ class StationNextChangeSensor(CoordinatorEntity, SensorEntity):
 
         return attributes
 
-    async def async_update(self) -> None:
-        """Update the sensor and clear cache."""
-        await super().async_update()
+    def _handle_coordinator_update(self) -> None:
+        """Clear cached state after coordinator updates."""
         self._cached_next_change = None
+        super()._handle_coordinator_update()
 
 
 class StationServiceBinarySensor(CoordinatorEntity, BinarySensorEntity):

--- a/custom_components/osservaprezzi_carburanti/services.yaml
+++ b/custom_components/osservaprezzi_carburanti/services.yaml
@@ -1,0 +1,9 @@
+force_csv_update:
+  name: Force CSV update
+  description: Forces an immediate download and refresh of the CSV station database for all configured stations.
+clear_cache:
+  name: Clear CSV cache
+  description: Clears the cached CSV station data and re-downloads a fresh copy.
+compare_stations:
+  name: Compare station prices
+  description: Returns a comparison of fuel prices across all configured stations.

--- a/custom_components/osservaprezzi_carburanti/translations/en.json
+++ b/custom_components/osservaprezzi_carburanti/translations/en.json
@@ -41,13 +41,6 @@
   },
   "entity": {
     "sensor": {
-      "station_open_closed": {
-        "name": "Station Open",
-        "state": {
-          "on": "Open",
-          "off": "Closed"
-        }
-      },
       "next_change": {
         "name": "Next Schedule Change",
         "state": {
@@ -77,6 +70,13 @@
       }
     },
     "binary_sensor": {
+      "station_open_closed": {
+        "name": "Station Open",
+        "state": {
+          "on": "Open",
+          "off": "Closed"
+        }
+      },
       "service": {
         "food_beverage": {
           "name": "Food&Beverage",

--- a/custom_components/osservaprezzi_carburanti/translations/en.json
+++ b/custom_components/osservaprezzi_carburanti/translations/en.json
@@ -77,51 +77,49 @@
           "off": "Closed"
         }
       },
-      "service": {
-        "food_beverage": {
-          "name": "Food&Beverage",
-          "description": "Bar, restaurant or refreshment point"
-        },
-        "workshop": {
-          "name": "Workshop",
-          "description": "Repair and maintenance service"
-        },
-        "parking": {
-          "name": "Camper/Truck Parking",
-          "description": "Parking area for campers and trucks"
-        },
-        "dump_station": {
-          "name": "Camper Dump Station",
-          "description": "Black/gray water dump point"
-        },
-        "playground": {
-          "name": "Children's Area",
-          "description": "Playground for children"
-        },
-        "atm": {
-          "name": "ATM",
-          "description": "Automatic teller machine"
-        },
-        "disabled_access": {
-          "name": "Disabled Services",
-          "description": "Services accessible for disabled people"
-        },
-        "wifi": {
-          "name": "Wi-Fi",
-          "description": "Free or paid Wi-Fi connection"
-        },
-        "tire_service": {
-          "name": "Tire Service",
-          "description": "Tire and tire service"
-        },
-        "car_wash": {
-          "name": "Car Wash",
-          "description": "Car washing service"
-        },
-        "ev_charging": {
-          "name": "EV Charging",
-          "description": "Charging stations for electric vehicles"
-        }
+      "food_beverage": {
+        "name": "Food&Beverage",
+        "description": "Bar, restaurant or refreshment point"
+      },
+      "workshop": {
+        "name": "Workshop",
+        "description": "Repair and maintenance service"
+      },
+      "parking": {
+        "name": "Camper/Truck Parking",
+        "description": "Parking area for campers and trucks"
+      },
+      "dump_station": {
+        "name": "Camper Dump Station",
+        "description": "Black/gray water dump point"
+      },
+      "playground": {
+        "name": "Children's Area",
+        "description": "Playground for children"
+      },
+      "atm": {
+        "name": "ATM",
+        "description": "Automatic teller machine"
+      },
+      "disabled_access": {
+        "name": "Disabled Services",
+        "description": "Services accessible for disabled people"
+      },
+      "wifi": {
+        "name": "Wi-Fi",
+        "description": "Free or paid Wi-Fi connection"
+      },
+      "tire_service": {
+        "name": "Tire Service",
+        "description": "Tire and tire service"
+      },
+      "car_wash": {
+        "name": "Car Wash",
+        "description": "Car washing service"
+      },
+      "ev_charging": {
+        "name": "EV Charging",
+        "description": "Charging stations for electric vehicles"
       }
     }
   },

--- a/custom_components/osservaprezzi_carburanti/translations/en.json
+++ b/custom_components/osservaprezzi_carburanti/translations/en.json
@@ -61,6 +61,9 @@
       "location": {
         "name": "Station Location"
       },
+      "station_geolocation": {
+        "name": "Station Geo Location"
+      },
       "info": {
         "name": "Name",
         "nome_impianto": "Station Name",
@@ -120,6 +123,20 @@
           "description": "Charging stations for electric vehicles"
         }
       }
+    }
+  },
+  "services": {
+    "force_csv_update": {
+      "name": "Force CSV update",
+      "description": "Forces an immediate download and refresh of the CSV station database for all configured stations."
+    },
+    "clear_cache": {
+      "name": "Clear CSV cache",
+      "description": "Clears the cached CSV station data and re-downloads a fresh copy."
+    },
+    "compare_stations": {
+      "name": "Compare station prices",
+      "description": "Returns a comparison of fuel prices across all configured stations."
     }
   },
   "title": "Osservaprezzi Carburanti"

--- a/custom_components/osservaprezzi_carburanti/translations/it.json
+++ b/custom_components/osservaprezzi_carburanti/translations/it.json
@@ -61,6 +61,9 @@
       "location": {
         "name": "Posizione Stazione"
       },
+      "station_geolocation": {
+        "name": "Geolocalizzazione Stazione"
+      },
       "info": {
         "name": "Nome",
         "nome_impianto": "Nome Impianto",
@@ -121,5 +124,20 @@
         }
       }
     }
-  }
+  },
+  "services": {
+    "force_csv_update": {
+      "name": "Forza aggiornamento CSV",
+      "description": "Forza il download e l'aggiornamento immediato del database CSV delle stazioni per tutte le stazioni configurate."
+    },
+    "clear_cache": {
+      "name": "Cancella cache CSV",
+      "description": "Cancella i dati CSV memorizzati nella cache e scarica una copia aggiornata."
+    },
+    "compare_stations": {
+      "name": "Confronta prezzi stazioni",
+      "description": "Restituisce un confronto dei prezzi dei carburanti tra tutte le stazioni configurate."
+    }
+  },
+  "title": "Osservaprezzi Carburanti"
 }

--- a/custom_components/osservaprezzi_carburanti/translations/it.json
+++ b/custom_components/osservaprezzi_carburanti/translations/it.json
@@ -77,51 +77,49 @@
           "off": "Chiusa"
         }
       },
-      "service": {
-        "food_beverage": {
-          "name": "Food&Beverage",
-          "description": "Bar, ristorante o punto ristoro"
-        },
-        "workshop": {
-          "name": "Officina",
-          "description": "Servizio di riparazione e manutenzione"
-        },
-        "parking": {
-          "name": "Sosta Camper/Tir",
-          "description": "Area di sosta per camper e autotreni"
-        },
-        "dump_station": {
-          "name": "Scarico per camper",
-          "description": "Punto di scarico acque nere/grigie"
-        },
-        "playground": {
-          "name": "Area bambini",
-          "description": "Area giochi per bambini"
-        },
-        "atm": {
-          "name": "Bancomat",
-          "description": "Sportello automatico ATM"
-        },
-        "disabled_access": {
-          "name": "Servizi per disabili",
-          "description": "Servizi accessibili per persone con disabilità"
-        },
-        "wifi": {
-          "name": "Wi-Fi",
-          "description": "Connessione Wi-Fi gratuita o a pagamento"
-        },
-        "tire_service": {
-          "name": "Gommista",
-          "description": "Servizio pneumatici e gommista"
-        },
-        "car_wash": {
-          "name": "Autolavaggio",
-          "description": "Servizio di lavaggio auto"
-        },
-        "ev_charging": {
-          "name": "Ricarica elettrica",
-          "description": "Colonnine per ricarica veicoli elettrici"
-        }
+      "food_beverage": {
+        "name": "Food&Beverage",
+        "description": "Bar, ristorante o punto ristoro"
+      },
+      "workshop": {
+        "name": "Officina",
+        "description": "Servizio di riparazione e manutenzione"
+      },
+      "parking": {
+        "name": "Sosta Camper/Tir",
+        "description": "Area di sosta per camper e autotreni"
+      },
+      "dump_station": {
+        "name": "Scarico per camper",
+        "description": "Punto di scarico acque nere/grigie"
+      },
+      "playground": {
+        "name": "Area bambini",
+        "description": "Area giochi per bambini"
+      },
+      "atm": {
+        "name": "Bancomat",
+        "description": "Sportello automatico ATM"
+      },
+      "disabled_access": {
+        "name": "Servizi per disabili",
+        "description": "Servizi accessibili per persone con disabilità"
+      },
+      "wifi": {
+        "name": "Wi-Fi",
+        "description": "Connessione Wi-Fi gratuita o a pagamento"
+      },
+      "tire_service": {
+        "name": "Gommista",
+        "description": "Servizio pneumatici e gommista"
+      },
+      "car_wash": {
+        "name": "Autolavaggio",
+        "description": "Servizio di lavaggio auto"
+      },
+      "ev_charging": {
+        "name": "Ricarica elettrica",
+        "description": "Colonnine per ricarica veicoli elettrici"
       }
     }
   },

--- a/custom_components/osservaprezzi_carburanti/translations/it.json
+++ b/custom_components/osservaprezzi_carburanti/translations/it.json
@@ -41,13 +41,6 @@
   },
   "entity": {
     "sensor": {
-      "station_open_closed": {
-        "name": "Stazione Aperta",
-        "state": {
-          "on": "Aperta",
-          "off": "Chiusa"
-        }
-      },
       "next_change": {
         "name": "Prossimo Cambio Orario",
         "state": {
@@ -77,6 +70,13 @@
       }
     },
     "binary_sensor": {
+      "station_open_closed": {
+        "name": "Stazione Aperta",
+        "state": {
+          "on": "Aperta",
+          "off": "Chiusa"
+        }
+      },
       "service": {
         "food_beverage": {
           "name": "Food&Beverage",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,62 @@
+"""Shared test fixtures and mock helpers."""
+from __future__ import annotations
+import sys
+from unittest.mock import MagicMock
+
+
+class _MockEntity: pass
+class _MockSensorEntity(_MockEntity): pass
+class _MockBinarySensorEntity(_MockEntity): pass
+class _MockCoordinatorEntity(_MockEntity): pass
+class _MockConfigFlow: pass
+class _MockOptionsFlow: pass
+
+
+def _mock_ha_modules():
+    ha_modules = [
+        "homeassistant",
+        "homeassistant.components",
+        "homeassistant.components.sensor",
+        "homeassistant.components.binary_sensor",
+        "homeassistant.config_entries",
+        "homeassistant.core",
+        "homeassistant.helpers",
+        "homeassistant.helpers.entity",
+        "homeassistant.helpers.entity_platform",
+        "homeassistant.helpers.update_coordinator",
+        "homeassistant.helpers.typing",
+        "homeassistant.helpers.aiohttp_client",
+        "homeassistant.helpers.event",
+        "homeassistant.util",
+        "homeassistant.util.dt",
+        "homeassistant.const",
+        "homeassistant.exceptions",
+        "homeassistant.data_entry_flow",
+        "aiohttp",
+        "voluptuous",
+    ]
+    for mod_name in ha_modules:
+        if mod_name not in sys.modules:
+            sys.modules[mod_name] = MagicMock()
+
+    sys.modules["homeassistant.components.sensor"].SensorEntity = _MockSensorEntity
+    sys.modules["homeassistant.components.sensor"].SensorStateClass = MagicMock(
+        MEASUREMENT="measurement"
+    )
+    sys.modules["homeassistant.components.binary_sensor"].BinarySensorEntity = _MockBinarySensorEntity
+    sys.modules["homeassistant.helpers.update_coordinator"].CoordinatorEntity = _MockCoordinatorEntity
+    sys.modules["homeassistant.helpers.entity"].DeviceInfo = dict
+    sys.modules["homeassistant.helpers.entity"].EntityCategory = MagicMock(
+        DIAGNOSTIC="diagnostic"
+    )
+    sys.modules["homeassistant.helpers.typing"].StateType = object
+    sys.modules["homeassistant.const"].Platform = MagicMock(SENSOR="sensor")
+    sys.modules["homeassistant.exceptions"].HomeAssistantError = Exception
+    sys.modules["homeassistant.exceptions"].ConfigEntryNotReady = Exception
+    sys.modules["homeassistant.data_entry_flow"].FlowResult = dict
+    sys.modules["homeassistant.config_entries"].ConfigFlow = _MockConfigFlow
+    sys.modules["homeassistant.config_entries"].OptionsFlowWithConfigEntry = _MockOptionsFlow
+    sys.modules["homeassistant.core"].callback = lambda f: f
+
+
+_mock_ha_modules()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -18,6 +18,7 @@ def _mock_ha_modules():
         "homeassistant.components",
         "homeassistant.components.sensor",
         "homeassistant.components.binary_sensor",
+        "homeassistant.components.geo_location",
         "homeassistant.config_entries",
         "homeassistant.core",
         "homeassistant.helpers",
@@ -32,7 +33,6 @@ def _mock_ha_modules():
         "homeassistant.const",
         "homeassistant.exceptions",
         "homeassistant.data_entry_flow",
-        "aiohttp",
         "voluptuous",
     ]
     for mod_name in ha_modules:
@@ -44,7 +44,10 @@ def _mock_ha_modules():
         MEASUREMENT="measurement"
     )
     sys.modules["homeassistant.components.binary_sensor"].BinarySensorEntity = _MockBinarySensorEntity
+    sys.modules["homeassistant.components.geo_location"].GeolocationEvent = _MockEntity
     sys.modules["homeassistant.helpers.update_coordinator"].CoordinatorEntity = _MockCoordinatorEntity
+    sys.modules["homeassistant.helpers.update_coordinator"].DataUpdateCoordinator = _MockCoordinatorEntity
+    sys.modules["homeassistant.helpers.update_coordinator"].UpdateFailed = Exception
     sys.modules["homeassistant.helpers.entity"].DeviceInfo = dict
     sys.modules["homeassistant.helpers.entity"].EntityCategory = MagicMock(
         DIAGNOSTIC="diagnostic"

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -1,0 +1,57 @@
+"""Tests for coordinator retry helpers."""
+from __future__ import annotations
+
+import asyncio
+import sys
+from typing import Any, cast
+
+import aiohttp
+
+
+sys.path.insert(0, ".")
+
+from custom_components.osservaprezzi_carburanti.coordinator import (
+    CarburantiDataUpdateCoordinator,
+)
+
+
+def _make_response_error(
+    status: int,
+    headers: dict[str, str] | None = None,
+) -> aiohttp.ClientResponseError:
+    """Create a minimal response error for tests."""
+    return aiohttp.ClientResponseError(
+        request_info=cast(Any, None),
+        history=(),
+        status=status,
+        message="test",
+        headers=cast(Any, headers),
+    )
+
+
+class TestRetryDelay:
+    def test_uses_retry_after_header(self) -> None:
+        err = _make_response_error(429, {"Retry-After": "15"})
+        assert CarburantiDataUpdateCoordinator._get_retry_delay(err, 30) == 15
+
+    def test_ignores_invalid_retry_after_header(self) -> None:
+        err = _make_response_error(429, {"Retry-After": "invalid"})
+        assert CarburantiDataUpdateCoordinator._get_retry_delay(err, 30) == 30
+
+    def test_ignores_non_positive_retry_after_header(self) -> None:
+        err = _make_response_error(429, {"Retry-After": "0"})
+        assert CarburantiDataUpdateCoordinator._get_retry_delay(err, 30) == 30
+
+
+class TestTransientErrors:
+    def test_timeout_is_transient(self) -> None:
+        assert CarburantiDataUpdateCoordinator._is_transient_error(asyncio.TimeoutError()) is True
+
+    def test_404_is_not_transient(self) -> None:
+        assert CarburantiDataUpdateCoordinator._is_transient_error(_make_response_error(404)) is False
+
+    def test_429_is_transient(self) -> None:
+        assert CarburantiDataUpdateCoordinator._is_transient_error(_make_response_error(429)) is True
+
+    def test_client_error_is_transient(self) -> None:
+        assert CarburantiDataUpdateCoordinator._is_transient_error(aiohttp.ClientError()) is True

--- a/tests/test_cron_helper.py
+++ b/tests/test_cron_helper.py
@@ -1,0 +1,41 @@
+"""Tests for cron helper functions."""
+from __future__ import annotations
+import sys
+from datetime import datetime, timezone
+
+import pytest
+
+
+sys.path.insert(0, ".")
+
+from custom_components.osservaprezzi_carburanti.cron_helper import validate_cron_expression
+
+try:
+    from cronsim import CronSim
+except ImportError:
+    CronSim = None
+
+
+@pytest.mark.skipif(CronSim is None, reason="cronsim not installed")
+class TestCronHelper:
+    def test_validate_valid_expression(self):
+        assert validate_cron_expression("30 8 * * *") is True
+
+    def test_validate_valid_every_hour(self):
+        assert validate_cron_expression("0 * * * *") is True
+
+    def test_validate_valid_specific_days(self):
+        assert validate_cron_expression("30 7 * * 1-5") is True
+
+    def test_validate_invalid_expression(self):
+        assert validate_cron_expression("not valid") is False
+
+    def test_validate_empty_string(self):
+        assert validate_cron_expression("") is False
+
+    def test_get_next_run_time(self):
+        from custom_components.osservaprezzi_carburanti.cron_helper import get_next_run_time
+        base = datetime(2025, 3, 15, 10, 0, tzinfo=timezone.utc)
+        next_run = get_next_run_time("30 8 * * *", base)
+        assert next_run.hour == 8
+        assert next_run.minute == 30

--- a/tests/test_csv_manager.py
+++ b/tests/test_csv_manager.py
@@ -1,0 +1,98 @@
+"""Tests for CSV manager parsing logic."""
+from __future__ import annotations
+import sys
+from unittest.mock import MagicMock
+
+import pytest
+
+
+sys.path.insert(0, ".")
+
+from custom_components.osservaprezzi_carburanti.csv_manager import CSVStationManager, CSV_COLUMNS
+
+
+@pytest.fixture
+def csv_manager():
+    hass = MagicMock()
+    hass.config.path.return_value = "/tmp/test_storage"
+    return CSVStationManager(hass)
+
+
+PIPE_CSV_LINES = [
+    "2025-01-15T10:00:00",
+    "idImpianto|Gestore|Bandiera|Tipo Impianto|Nome Impianto|Indirizzo|Comune|Provincia|Latitudine|Longitudine",
+    "12345|Operator A|Brand X|Stradale|Station Alpha|Via Roma 1|Roma|RM|41.902782|12.496366",
+    "67890|Operator B|Brand Y|Autostradale|Station Beta|Via Milano 2|Milano|MI|45.4642|9.1900",
+    "11111|Operator C|Brand Z|Stradale|Station NoCoords|Via Napoli 3|Napoli|NA||",
+]
+
+SEMICOLON_CSV_LINES = [
+    "2025-01-15T10:00:00",
+    "idImpianto;Gestore;Bandiera;Tipo Impianto;Nome Impianto;Indirizzo;Comune;Provincia;Latitudine;Longitudine",
+    "12345;Operator A;Brand X;Stradale;Station Alpha;Via Roma 1;Roma;RM;41,902782;12,496366",
+    "67890;Operator B;Brand Y;Autostradale;Station Beta;Via Milano 2;Milano;MI;45,4642;9,1900",
+]
+
+
+class TestCSVParsing:
+    def test_parse_pipe_separated(self, csv_manager):
+        result = csv_manager._parse_csv_lines(PIPE_CSV_LINES)
+        assert result is True
+        assert len(csv_manager._stations_cache) == 2
+        assert "12345" in csv_manager._stations_cache
+        assert "67890" in csv_manager._stations_cache
+
+    def test_parse_semicolon_separated(self, csv_manager):
+        result = csv_manager._parse_csv_lines(SEMICOLON_CSV_LINES)
+        assert result is True
+        assert len(csv_manager._stations_cache) == 2
+
+    def test_italian_decimal_format(self, csv_manager):
+        csv_manager._parse_csv_lines(SEMICOLON_CSV_LINES)
+        station = csv_manager._stations_cache.get("12345")
+        assert station is not None
+        assert isinstance(station["latitude"], float)
+        assert isinstance(station["longitude"], float)
+        assert abs(station["latitude"] - 41.902782) < 0.001
+
+    def test_stations_without_coords_excluded(self, csv_manager):
+        csv_manager._parse_csv_lines(PIPE_CSV_LINES)
+        assert "11111" not in csv_manager._stations_cache
+
+    def test_insufficient_lines(self, csv_manager):
+        assert csv_manager._parse_csv_lines(["header"]) is False
+        assert csv_manager._parse_csv_lines([]) is False
+
+    def test_station_data_fields(self, csv_manager):
+        csv_manager._parse_csv_lines(PIPE_CSV_LINES)
+        station = csv_manager._stations_cache["12345"]
+        assert station["operator"] == "Operator A"
+        assert station["brand"] == "Brand X"
+        assert station["station_type"] == "Stradale"
+        assert station["name"] == "Station Alpha"
+        assert station["address"] == "Via Roma 1"
+        assert station["municipality"] == "Roma"
+        assert station["province"] == "RM"
+
+    def test_get_station_by_id(self, csv_manager):
+        csv_manager._parse_csv_lines(PIPE_CSV_LINES)
+        station = csv_manager.get_station_by_id("12345")
+        assert station is not None
+        assert station["name"] == "Station Alpha"
+
+    def test_get_station_by_id_not_found(self, csv_manager):
+        csv_manager._parse_csv_lines(PIPE_CSV_LINES)
+        assert csv_manager.get_station_by_id("99999") is None
+
+    def test_is_data_available(self, csv_manager):
+        assert csv_manager.is_data_available() is False
+        csv_manager._parse_csv_lines(PIPE_CSV_LINES)
+        assert csv_manager.is_data_available() is True
+
+    def test_detect_separator_pipe(self, csv_manager):
+        csv_manager._parse_csv_lines(PIPE_CSV_LINES)
+        assert csv_manager._detected_separator == "|"
+
+    def test_detect_separator_semicolon(self, csv_manager):
+        csv_manager._parse_csv_lines(SEMICOLON_CSV_LINES)
+        assert csv_manager._detected_separator == ";"

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -1,0 +1,283 @@
+"""Tests for pure sensor helper functions."""
+from __future__ import annotations
+import sys
+from datetime import date, time
+
+import pytest
+
+
+sys.path.insert(0, ".")
+
+from custom_components.osservaprezzi_carburanti.sensor import (
+    _parse_time,
+    _is_italian_holiday,
+    _compute_easter,
+    _is_schedule_open,
+    _find_schedule_for_day,
+    _has_valid_opening_hours,
+    _get_fuel_icon,
+    HOLIDAY_SCHEDULE_ID,
+)
+
+
+class TestParseTime:
+    def test_hh_mm_format(self):
+        assert _parse_time("07:30") == time(7, 30)
+
+    def test_hh_mm_format_midnight(self):
+        assert _parse_time("00:00") == time(0, 0)
+
+    def test_hh_dot_mm_format(self):
+        assert _parse_time("07.30") == time(7, 30)
+
+    def test_hh_dot_mm_format_24(self):
+        assert _parse_time("24.00") == time(0, 0)
+
+    def test_hh_only_format(self):
+        assert _parse_time("7") == time(7, 0)
+
+    def test_hh_only_format_24(self):
+        assert _parse_time("24") == time(0, 0)
+
+    def test_none_returns_none(self):
+        assert _parse_time(None) is None
+
+    def test_empty_string_returns_none(self):
+        assert _parse_time("") is None
+
+    def test_invalid_returns_none(self):
+        assert _parse_time("abc") is None
+
+
+class TestComputeEaster:
+    def test_easter_2024(self):
+        assert _compute_easter(2024) == date(2024, 3, 31)
+
+    def test_easter_2025(self):
+        assert _compute_easter(2025) == date(2025, 4, 20)
+
+    def test_easter_2026(self):
+        assert _compute_easter(2026) == date(2026, 4, 5)
+
+    def test_easter_2023(self):
+        assert _compute_easter(2023) == date(2023, 4, 9)
+
+
+class TestIsItalianHoliday:
+    def test_capodanno(self):
+        assert _is_italian_holiday(date(2025, 1, 1)) is True
+
+    def test_epifania(self):
+        assert _is_italian_holiday(date(2025, 1, 6)) is True
+
+    def test_liberazione(self):
+        assert _is_italian_holiday(date(2025, 4, 25)) is True
+
+    def test_festa_lavoro(self):
+        assert _is_italian_holiday(date(2025, 5, 1)) is True
+
+    def test_festa_repubblica(self):
+        assert _is_italian_holiday(date(2025, 6, 2)) is True
+
+    def test_ferragosto(self):
+        assert _is_italian_holiday(date(2025, 8, 15)) is True
+
+    def test_tutti_santi(self):
+        assert _is_italian_holiday(date(2025, 11, 1)) is True
+
+    def test_immacolata(self):
+        assert _is_italian_holiday(date(2025, 12, 8)) is True
+
+    def test_natale(self):
+        assert _is_italian_holiday(date(2025, 12, 25)) is True
+
+    def test_santo_stefano(self):
+        assert _is_italian_holiday(date(2025, 12, 26)) is True
+
+    def test_easter_monday_2025(self):
+        assert _is_italian_holiday(date(2025, 4, 21)) is True
+
+    def test_easter_sunday_2025(self):
+        assert _is_italian_holiday(date(2025, 4, 20)) is True
+
+    def test_regular_day(self):
+        assert _is_italian_holiday(date(2025, 3, 15)) is False
+
+    def test_not_holiday(self):
+        assert _is_italian_holiday(date(2025, 7, 14)) is False
+
+
+class TestIsScheduleOpen:
+    def test_continuous_hours_open(self):
+        schedule = {
+            "flagOrarioContinuato": True,
+            "oraAperturaOrarioContinuato": "08:00",
+            "oraChiusuraOrarioContinuato": "20:00",
+        }
+        assert _is_schedule_open(schedule, time(12, 0)) is True
+
+    def test_continuous_hours_closed(self):
+        schedule = {
+            "flagOrarioContinuato": True,
+            "oraAperturaOrarioContinuato": "08:00",
+            "oraChiusuraOrarioContinuato": "20:00",
+        }
+        assert _is_schedule_open(schedule, time(21, 0)) is False
+
+    def test_split_hours_morning_open(self):
+        schedule = {
+            "flagOrarioContinuato": False,
+            "oraAperturaMattina": "07:00",
+            "oraChiusuraMattina": "12:00",
+            "oraAperturaPomeriggio": "15:00",
+            "oraChiusuraPomeriggio": "19:00",
+        }
+        assert _is_schedule_open(schedule, time(9, 0)) is True
+
+    def test_split_hours_afternoon_open(self):
+        schedule = {
+            "flagOrarioContinuato": False,
+            "oraAperturaMattina": "07:00",
+            "oraChiusuraMattina": "12:00",
+            "oraAperturaPomeriggio": "15:00",
+            "oraChiusuraPomeriggio": "19:00",
+        }
+        assert _is_schedule_open(schedule, time(16, 0)) is True
+
+    def test_split_hours_closed_gap(self):
+        schedule = {
+            "flagOrarioContinuato": False,
+            "oraAperturaMattina": "07:00",
+            "oraChiusuraMattina": "12:00",
+            "oraAperturaPomeriggio": "15:00",
+            "oraChiusuraPomeriggio": "19:00",
+        }
+        assert _is_schedule_open(schedule, time(13, 30)) is False
+
+    def test_overnight_open(self):
+        schedule = {
+            "flagOrarioContinuato": True,
+            "oraAperturaOrarioContinuato": "22:00",
+            "oraChiusuraOrarioContinuato": "06:00",
+        }
+        assert _is_schedule_open(schedule, time(23, 0)) is True
+
+    def test_overnight_open_after_midnight(self):
+        schedule = {
+            "flagOrarioContinuato": True,
+            "oraAperturaOrarioContinuato": "22:00",
+            "oraChiusuraOrarioContinuato": "06:00",
+        }
+        assert _is_schedule_open(schedule, time(3, 0)) is True
+
+    def test_overnight_closed(self):
+        schedule = {
+            "flagOrarioContinuato": True,
+            "oraAperturaOrarioContinuato": "22:00",
+            "oraChiusuraOrarioContinuato": "06:00",
+        }
+        assert _is_schedule_open(schedule, time(15, 0)) is False
+
+
+class TestFindScheduleForDay:
+    def test_finds_regular_weekday(self):
+        opening_hours = [
+            {"giornoSettimanaId": 1},
+            {"giornoSettimanaId": 2},
+        ]
+        result = _find_schedule_for_day(opening_hours, 1, date(2025, 3, 17))
+        assert result is not None
+        assert result["giornoSettimanaId"] == 1
+
+    def test_returns_none_for_missing_day(self):
+        opening_hours = [
+            {"giornoSettimanaId": 1},
+        ]
+        result = _find_schedule_for_day(opening_hours, 5, date(2025, 3, 17))
+        assert result is None
+
+    def test_uses_holiday_schedule_on_holiday(self):
+        opening_hours = [
+            {"giornoSettimanaId": 1, "flagChiusura": True},
+            {"giornoSettimanaId": HOLIDAY_SCHEDULE_ID, "flagOrarioContinuato": True,
+             "oraAperturaOrarioContinuato": "08:00", "oraChiusuraOrarioContinuato": "13:00"},
+        ]
+        result = _find_schedule_for_day(opening_hours, 1, date(2025, 1, 1))
+        assert result is not None
+        assert result["giornoSettimanaId"] == HOLIDAY_SCHEDULE_ID
+
+    def test_regular_day_ignores_holiday_schedule(self):
+        opening_hours = [
+            {"giornoSettimanaId": 1, "flagOrarioContinuato": True,
+             "oraAperturaOrarioContinuato": "08:00", "oraChiusuraOrarioContinuato": "20:00"},
+            {"giornoSettimanaId": HOLIDAY_SCHEDULE_ID, "flagChiusura": True},
+        ]
+        result = _find_schedule_for_day(opening_hours, 1, date(2025, 3, 17))
+        assert result is not None
+        assert result["giornoSettimanaId"] == 1
+
+
+class TestHasValidOpeningHours:
+    def test_empty_data(self):
+        assert _has_valid_opening_hours({}) is False
+        assert _has_valid_opening_hours(None) is False
+
+    def test_no_opening_hours_key(self):
+        assert _has_valid_opening_hours({"fuels": {}}) is False
+
+    def test_empty_opening_hours(self):
+        assert _has_valid_opening_hours({"opening_hours": []}) is False
+
+    def test_h24(self):
+        assert _has_valid_opening_hours({
+            "opening_hours": [{"flagH24": True}]
+        }) is True
+
+    def test_continuous_hours(self):
+        assert _has_valid_opening_hours({
+            "opening_hours": [{
+                "flagOrarioContinuato": True,
+                "oraAperturaOrarioContinuato": "08:00",
+                "oraChiusuraOrarioContinuato": "20:00",
+            }]
+        }) is True
+
+    def test_split_hours(self):
+        assert _has_valid_opening_hours({
+            "opening_hours": [{
+                "oraAperturaMattina": "07:00",
+                "oraChiusuraMattina": "12:00",
+                "oraAperturaPomeriggio": "15:00",
+                "oraChiusuraPomeriggio": "19:00",
+            }]
+        }) is True
+
+    def test_all_closed(self):
+        assert _has_valid_opening_hours({
+            "opening_hours": [{"flagChiusura": True}]
+        }) is False
+
+    def test_no_valid_times(self):
+        assert _has_valid_opening_hours({
+            "opening_hours": [{}]
+        }) is False
+
+
+class TestGetFuelIcon:
+    def test_benzina(self):
+        assert _get_fuel_icon("Benzina") == "mdi:gas-station"
+
+    def test_gasolio(self):
+        assert _get_fuel_icon("Gasolio") == "mdi:fuel"
+
+    def test_diesel(self):
+        assert _get_fuel_icon("Diesel") == "mdi:fuel"
+
+    def test_gpl(self):
+        assert _get_fuel_icon("GPL") == "mdi:gas-cylinder"
+
+    def test_metano(self):
+        assert _get_fuel_icon("Metano") == "mdi:molecule-co2"
+
+    def test_other(self):
+        assert _get_fuel_icon("Unknown Fuel") == "mdi:currency-eur"


### PR DESCRIPTION
## Summary

Major feature update introducing HA services, geo_location platform, robust retry/backoff logic, price change tracking, and a full test suite. Also adds project documentation files and modernizes the codebase with type annotation cleanup.

## What's Changed

### New Features
- **HA Services** (`force_csv_update`, `clear_cache`, `compare_stations`): three global services registered once per domain and cleaned up on last entry unload.
- **Geo Location platform** (`geo_location.py`): stations now appear as map entities in the HA map panel.
- **Price change tracking**: fuel sensors now expose `previous_price` and `price_changed_at` attributes.
- **Italian holiday support**: open/closed and next-change sensors now correctly fall back to the holiday schedule (`giornoSettimanaId = 8`) on Italian public holidays.
- **API rate limiting**: outbound station API requests are serialized with a configurable `API_REQUEST_INTERVAL_SECONDS` delay to avoid bursts.

### Improvements
- **Retry with exponential backoff** (3 attempts: 30s → 60s → 120s) for transient API errors; respects `Retry-After` headers on 429 responses.
- **Stale data fallback**: coordinator returns last known data on transient failures instead of raising `UpdateFailed`.
- **Cron scheduler refactor**: switched from `async_track_time_interval` to `async_track_point_in_utc_time` for precise one-shot scheduling; `_schedule_next_refresh` is re-invoked in a `finally` block after each refresh.
- **CSV parsing deduplication**: merged `_parse_csv_data_sync` and `_parse_csv_data_sync_from_file` into a single `_parse_csv_lines` helper.
- **Open/closed logic extracted** into standalone `_is_schedule_open` and `_find_schedule_for_day` helpers, removing duplicated code between `StationOpenClosedBinarySensor` and `StationNextChangeSensor`.
- **Entity cache invalidation** now uses `_handle_coordinator_update` instead of overriding `async_update`.

### Bug Fixes
- Fixed `aiohttp.ClientTimeout` usage (was passing a bare `int`).
- Fixed translation key structure for binary sensor services (flattened out of `service.*` nesting).
- Fixed `station_open_closed` moved from `sensor` to `binary_sensor` in translations.
- Fixed comment in `DEFAULT_CRON_EXPRESSION` (08:30, not 07:30).

### Docs & Project Files
- Added `AGENTS.md`: guide for agentic coding agents working in this repository.
- Added `CHANGELOG.md`: full changelog following Keep a Changelog format.
- Added `LICENSE`: MIT license.
- Expanded `.gitignore` with Python, venv, IDE, OS, and dist patterns.
- Added `services.yaml` with UI-visible service definitions.

### Tests
- Added `tests/` directory with `conftest.py` (HA module mocking), and test files covering:
  - `test_coordinator.py`: retry delay and transient error classification.
  - `test_cron_helper.py`: cron validation and next-run time calculation.
  - `test_csv_manager.py`: pipe/semicolon parsing, Italian decimal coords, field mapping.
  - `test_sensor.py`: `_parse_time`, `_compute_easter`, `_is_italian_holiday`, `_is_schedule_open`, `_find_schedule_for_day`, `_has_valid_opening_hours`, `_get_fuel_icon`.

### Type Annotation Cleanup
- Replaced `Optional[X]`, `Dict[str, ...]`, `List[...]` with modern `X | None`, `dict[str, ...]`, `list[...]` throughout.
- Updated `FlowResult` → `ConfigFlowResult` in config flow.